### PR TITLE
Add extended support for idle tuning

### DIFF
--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -28,9 +28,7 @@
 
 This option controls garbage collection processing with compaction when the status of the OpenJ9 VM is set to idle.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:**  
-- This option applies only to Linux on x86-32 and x86-64 architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use.  
-- This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
 ## Syntax
 

--- a/docs/xxidletuninggconidle.md
+++ b/docs/xxidletuninggconidle.md
@@ -28,9 +28,7 @@
 
 This option can be used to reduce the memory footprint of the OpenJ9 VM when it is in an idle state.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:**  
-- This option applies only to Linux on x86-32 and x86-64 architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use.  
-- This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
 ## Syntax
 

--- a/docs/xxidletuningminfreeheaponidle.md
+++ b/docs/xxidletuningminfreeheaponidle.md
@@ -28,7 +28,7 @@
 
 This option controls the percentage of free memory pages in the object heap that can be released when the OpenJ9 VM is in an idle state.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:** This option applies only to Linux on x86-32 and x86-64 architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
 ## Syntax
 

--- a/docs/xxidletuningminidlewaittime.md
+++ b/docs/xxidletuningminidlewaittime.md
@@ -28,7 +28,7 @@
 
 When the OpenJ9 VM is idle, this option controls the minimum length of time that the VM must be idle before the status of the VM is set to idle. Further tuning options control the compaction of the object heap and the release of free memory pages, which reduces the footprint of the VM.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:** This option applies only to Linux on x86-32 and x86-64 architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
 ## Syntax
 


### PR DESCRIPTION
Update the -XX idletuning options to
indicate that they are now supported on
all Linux architectures.

Closes: #26

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>