### PR TITLE
Add two new -XX options to set heap as a %

### DIFF
--- a/docs/xxinitialrampercentage.md
+++ b/docs/xxinitialrampercentage.md
@@ -1,0 +1,38 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:InitialRAMPercentage
+
+This Oracle Hotspot option can be used to specify the initial size of the Java heap as a percentage of the total memory available to the VM. The option is recognized by the OpenJ9 VM and is provided for compatibility.
+
+## Syntax
+
+        -XX:InitialRAMPercentage=N
+
+: Where N is a value between 0 and 100, which can by of type "double". For example, 12.3456.
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i><span class="sr-only">Note</span> **Note:** If you set a value for [`-Xms`](xms.md), this option is ignored.
+
+
+<!-- ==== END OF TOPIC ==== xxinitialrampercentage.md ==== -->

--- a/docs/xxmaxrampercentage.md
+++ b/docs/xxmaxrampercentage.md
@@ -1,0 +1,38 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:MaxRAMPercentage
+
+This Oracle Hotspot option can be used to specify the maximum Java heap size as a percentage of the total memory available to the VM. The option is recognized by the OpenJ9 VM and is provided for compatibility.
+
+## Syntax
+
+        -XX:MaxRAMPercentage=N
+
+: Where N is a value between 0 and 100, which can by of type "double". For example, 12.3456.
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i><span class="sr-only">Note</span> **Note:** If you set a value for [`-Xmx`](xms.md), this option is ignored.
+
+
+<!-- ==== END OF TOPIC ==== xxmaxrampercentage.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -261,9 +261,11 @@ pages:
             - "-XX:IdleTuningMinFreeHeapOnIdle"                                  : xxidletuningminfreeheaponidle.md
             - "-XX:IdleTuningMinIdleWaitTime"                                    : xxidletuningminidlewaittime.md
             - "-XX:[+|-]IgnoreUnrecognizedVMOptions"                             : xxignoreunrecognizedvmoptions.md
+            - "-XX:InitialRAMPercentage"                                         : xxinitialrampercentage.md
             - "-XX:[+|-]InterleaveMemory"                                        : xxinterleavememory.md
             - "-XX:[+|-]LazySymbolResolution"                                    : xxlazysymbolresolution.md
             - "-XX:MaxDirectMemorySize"                                          : xxmaxdirectmemorysize.md
+            - "-XX:MaxRAMPercentage"                                             : xxmaxrampercentage.md
             - "-XXnosuballoc32bitmem"                                            : xxnosuballoc32bitmem.md
             - "-XX:[+|-]PageAlignDirectMemory"                                   : xxpagealigndirectmemory.md
             - "-XX:[+|-]ReduceCPUMonitorOverhead"                                : xxreducecpumonitoroverhead.md


### PR DESCRIPTION
-XXMaxRAMPercentage=N and -XXInitialRAMPercentage=N

New in OpenJDK 10 w/Hotspot and recognized by
OpenJ9 in all JDKs for compatibility.

Closes: #25

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>