### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-enhancement.md
@@ -1,0 +1,10 @@
+---
+name: Documentation enhancement
+about: Suggestions to improve the documentation, not related to a change.
+
+---
+
+**Subject:**
+*E.g. component, feature, existing page*
+
+**Suggestion:**

--- a/.github/ISSUE_TEMPLATE/documentation-error.md
+++ b/.github/ISSUE_TEMPLATE/documentation-error.md
@@ -1,0 +1,11 @@
+---
+name: Documentation error
+about: For inaccuracies in existing topics, including typos.
+
+---
+
+**Page containing the error:**
+
+*www.eclipse.org/openj9/docs/*
+
+**Describe the error and the update needed:**

--- a/.github/ISSUE_TEMPLATE/new-documentation-change.md
+++ b/.github/ISSUE_TEMPLATE/new-documentation-change.md
@@ -1,0 +1,28 @@
+---
+name: New documentation changes
+about: Request updates as a result of external changes at github.com/eclipse/openj9
+
+---
+
+**Issue or pull request number:**
+*E.g. https://github.com/SueChaplain/mygitbook-ghpages/issues/1*
+
+**Overview:**
+*Describe the external change and the impact/benefit from a user perspective.*
+
+
+**Applies to the following JDK versions:**
+*E.g. 8 only / 8 and later / 9 and later*
+
+**Applies to the following platforms:**
+*E.g. All platforms / AIX / Linux X|P|Z / Windows / z/OS*
+
+**For new command line options:**
+
+- Option name and syntax: *e.g. -XX[+|-]NewOptionName*
+- If values are set:  
+	- Units for setting: *e.g. %, MB*
+	- Range: *e.g. 0-100*
+	- Default value: *e.g. 50*
+- Purpose:
+- Restrictions:


### PR DESCRIPTION
Issue templates should help us get the
information we need from OpenJ9 contributors
or from users who find problems with the
documentation.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>