### PR TITLE
Update Dockerfile to prevent pip upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,17 @@ FROM ubuntu:16.04
 MAINTAINER openj9.bot <openj9.bot@gmail.com> 
 
 # Set up for SSH (including SSH login fix to prevent user being logged out) and add PIP 
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python-setuptools git openjdk-8-jdk \
+# Removing this line to avoid compatibility errors. APT does not have a pip v10 package: && pip3 install --upgrade pip \
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python-setuptools git openjdk-8-jdk zip \
     && DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends \
     && DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends openssh-server \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --upgrade pip \
-    && python3 -m pip install -U setuptools \
+    && pip3 install -U setuptools \
     && sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd \
     && mkdir -p /var/run/sshd
 
+	
+	
 # Add MkDocs and dependencies
 COPY requirements.txt /tmp/
 RUN pip3 install --requirement /tmp/requirements.txt


### PR DESCRIPTION
Compatibility problems with pip installing
and upgrading via different package managers.
Preventing pip upgrading from 8 to 10. Must
reinstate when a pip 10 package is available
via apt.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>