### PR TITLE
Fix issues identified in a recent check

### DIFF
--- a/docs/dcomibmtoolsattachenable.md
+++ b/docs/dcomibmtoolsattachenable.md
@@ -48,7 +48,11 @@ On z/OS<sup>&reg;</sup> systems, the following default applies:
 
 ## Explanation
 
-A useful reference for information about the Java<sup>&trade;</sup> Attach API can be found at [http://docs.oracle.com/javase/8/docs/technotes/guides/attach/index.html](http://docs.oracle.com/javase/8/docs/technotes/guides/attach/index.html). As described by Oracle, *"The Attach API is an extension that provides a mechanism to attach to a Java virtual machine. A tool written in the Java Language, uses this API to attach to a target virtual machine and load its tool agent into that virtual machine."* For example, to late attach the IBM<sup>&reg;</sup> Health Center agent to a virtual machine (VM) that is already running.
+A useful reference for information about the Java<sup>&trade;</sup> Attach API can be found at [http://docs.oracle.com/javase/8/docs/technotes/guides/attach/index.html](http://docs.oracle.com/javase/8/docs/technotes/guides/attach/index.html). The following extract is taken from the Oracle documentation:
+
+> The Attach API is an extension that provides a mechanism to attach to a Java virtual machine. A tool written in the Java Language, uses this API to attach to a target  virtual machine and load its tool agent into that virtual machine.
+
+For example, to late attach the IBM<sup>&reg;</sup> Health Center agent to a virtual machine (VM) that is already running.
 
 The OpenJ9 implementation of the Attach API is equivalent to the Oracle implementation. However, the OpenJ9 implementation cannot be used to attach to, or accept attach requests from, other VM implementations.
 

--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -487,15 +487,15 @@ When `jdmpview` is started, the following parameters can be used during the sess
 
 ### whatis <hex_address>
 
-: Displays information about what is stored at the given memory address, `<hex_address>`. This command examines the memory location at `<hex_address>` and tries to find out more information about this address. For example:
+: Displays information about `whatis` stored at the given memory address, `<hex_address>`. This command examines the memory location at `<hex_address>` and tries to find out more information about this address. For example:
 
-        --------------------------------------------------------------------
+
         > whatis 0x8e76a8
 
         heap #1 - name: Default@19fce8
         0x8e76a8 is within heap segment: 8b0000 -- cb0000
         0x8e76a8 is start of an object of type java/lang/Thread
-        --------------------------------------------------------------------
+        
 
 ### x/ (examine)
 

--- a/docs/xdump.md
+++ b/docs/xdump.md
@@ -226,7 +226,7 @@ java -Xdump:java:events=unload,priority=100 -Xdump:what
 The results of the `-Xdump:what` option in the command are as follows.
 
 ```
-...6
+...
 ----------------------
 -Xdump:java:
     events=unload,

--- a/docs/xmint.md
+++ b/docs/xmint.md
@@ -25,15 +25,16 @@
 # -Xmint / -Xmaxt
 
 
-Sets the minimum and maximum proportion of time to spend in the garbage collection (GC) process as a percentage of the overall running time that included the last three GC runs. 
+Sets the minimum and maximum proportion of time to spend in the garbage collection (GC) process as a percentage of the overall running time that included the last three GC runs.
 
 - If the percentage of time drops to less than the minimum, the OpenJ9 VM tries to shrink the heap.
 
-- If the percentage of time exceeds the maximum, the OpenJ9 VM tries to expand the heap. 
+- If the percentage of time exceeds the maximum, the OpenJ9 VM tries to expand the heap.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:**  
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Restrictions</span> **Restrictions:**
+
 - This option applies only to GC policies that include stop-the-world (STW) operations, such as `-Xgcpolicy:optthruput`.  
--This option is ignored by the default policy `-Xgcpolicy:gencon`.
+- This option is ignored by the default policy `-Xgcpolicy:gencon`.
 
 ## Syntax
 

--- a/docs/xtrace.md
+++ b/docs/xtrace.md
@@ -96,6 +96,7 @@ Trace can produce large amounts of data in a very short time. Before running tra
 You must also think carefully about which components need to be traced and what level of tracing is required. For example, if you are tracing a suspected shared classes problem, it might be enough to trace all components at level 1, and **j9shr** at level 9, while `maximal` can be used to show parameters and other information for the failing component. Tracepoint components and trace levels are described in the following sections: [Tracepoint specification](#tracepoint-specification) and [Trace levels](#trace-levels).
 
 There are two types of tracepoints inside the VM:  
+
 - Regular tracepoints include method tracepoints, application tracepoints, data tracepoints inside the VM and data tracepoints inside class libraries. You can display regular tracepoint data on the screen or save the data to a file. You can also use command line options to trigger specific actions when regular tracepoints fire.
 - Auxiliary tracepoints are a special type of tracepoint that can be fired only when another tracepoint is being processed. For example, the stack frame information produced by the jstacktrace `-Xtrace:trigger` command. You cannot control where auxiliary tracepoint data is sent and you cannot set triggers on auxiliary tracepoints. Auxiliary tracepoint data is sent to the same destination as the tracepoint that caused them to be generated.
 

--- a/docs/xxusecontainersupport.md
+++ b/docs/xxusecontainersupport.md
@@ -40,15 +40,21 @@ If your application is running in a container that imposes a memory limit, and y
 | `-XX:+UseContainerSupport` | Enable  |                                                                                    |
 
 
-When using container technology, applications are typically run on their own and do not need to compete for memory. The VM detects when OpenJ9 is running inside a container that imposes a memory limit, and if `-XX:+UserContainerSupport` is set, adjusts the maximum Java heap size appropriately.
+When using container technology, applications are typically run on their own and do not need to compete for memory. The OpenJ9 VM detects when it is running inside a container that imposes a memory limit, and if `-XX:+UserContainerSupport` is set, adjusts the maximum Java heap size appropriately.
 
 The following table shows the values that are used when `-XX:+UserContainerSupport` is set:
 
-| Physical memory *&lt;size&gt;* | Maximum Java heap size  |
-|--------------------------------|-------------------------|
-| Less than 1 GB                 | 50% *&lt;size&gt;*      |
-| 1 GB - 2 GB                    | *&lt;size&gt;* - 512 MB |
-| Greater than 2 GB              | 75% *&lt;size&gt;*      |
+| Container memory limit *&lt;size&gt;* | Maximum Java heap size  |
+|---------------------------------------|-------------------------|
+| Less than 1 GB                        | 50% *&lt;size&gt;*      |
+| 1 GB - 2 GB                           | *&lt;size&gt;* - 512 MB |
+| Greater than 2 GB                     | 75% *&lt;size&gt;*      |
+
+The default heap size for containers takes affect only when the following conditions are met:
+
+1. The application is running in a container environment.
+2. The memory limit for the container is set.
+3. The `-XX:+UseContainerSupport` option is specified on the command line, which is expected to be the default in a future release.
 
 When [`-XX:MaxRAMPercentage`](xxmaxrampercentage.md) or [`-XX:InitialRAMPercentage`](xxinitialrampercentage.md) are used with `-XX:+UseContainerSupport`, the corresponding heap setting is determined based on the memory limit of the container. For example, to set the maximum heap size to 80% of the container memory, specify the following options:
 

--- a/docs/xxverboseverification.md
+++ b/docs/xxverboseverification.md
@@ -40,7 +40,7 @@ The Oracle documentation to support this option is no longer available, because 
 
 Use  `-XX:-VerboseVerification` to enable the output of verbose diagnostic data to `stderr` that is generated during verification from the class file `StackMapTable` attribute. The data provides extra contextual information about bytecode verification, which helps diagnose bytecode or stackmap deficiencies in the field.
 
-    Class files that have `StackMapTable` attributes (that is, class files that conform to version 50.0 or later of the class file format specification), are introduced in Java<sup>&trade;</sup> V6. Class files with `StackMapTable` attributes are marked as `new format` in the verbose output, as shown in the example. Class files without the `StackMapTable` attributes are marked as `old format`. The `StackMapTable` diagnostic information is available only to classes verified with the new format.
+Class files that have `StackMapTable` attributes (that is, class files that conform to version 50.0 or later of the class file format specification), are introduced in Java<sup>&trade;</sup> V6. Class files with `StackMapTable` attributes are marked as `new format` in the verbose output, as shown in the example. Class files without the `StackMapTable` attributes are marked as `old format`. The `StackMapTable` diagnostic information is available only to classes verified with the new format.
 
 
 Here is an example of `StackMapTable` diagnostic output:


### PR DESCRIPTION
Mostly these are bad markdown syntax,
which caused the HTML to be rendered not
quite as intended.

One further change to -XX:UseContainerSupport
that came from a recent review with development.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>