### PR TITLE
Update to include the 6 release/year policy

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -47,7 +47,7 @@ supported by any open project.
 | OpenJ9 release  | Release date        | JDK8 (LTS)| JDK9 | JDK10 | JDK11 (LTS) | JDK12   | JDK13 |
 |-----------------|---------------------|-----------|------|-------|-------------|---------|-------|
 | v0.8.0          | March 2018          | Yes       | No   |       |             |         |       |
-| v0.9.0          | August 2018 (\*1)   | Yes       | No   | Yes   |             |         |       |
+| v0.9.0          | August 2018         | Yes       | No   | Yes   |             |         |       |
 | v0.10.0         | September 2018 (\*1)| No        | No   | No    | Yes(\*3)    |         |       |
 | v0.11.0         | October 2018 (\*1)  | Yes       | No   | No    | Yes         |         |       |
 | v0.12.0         | January 2019 (\*1)  | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -31,6 +31,10 @@ user base. Currently, Eclipse OpenJ9 produces a new release every quarter that c
 currently supported by the OpenJDK community. We are committed to accepting problem reports when using
 Eclipse OpenJ9 against a supported OpenJDK level, with fixes being delivered in each release of Eclipse OpenJ9.
 
+In order to track the OpenJDK 6 month release cadence, OpenJ9 also produces two releases a year that support only
+a single JDK level.  These releases will occur in March and September with the intention of only supporting
+the corresponding new OpenJDK feature release (ie: 11, 12, ...).
+
 The following table summarizes which JDK levels are expected to be supported by which Eclipse OpenJ9 releases,
 along with projected release dates. All future dates and support expectations are predictions that might change
 depending on how the OpenJDK and OpenJ9 projects evolve over time. Note also that columns may be removed from
@@ -40,15 +44,17 @@ supported by any open project.
 
 ## Eclipse OpenJ9 releases
 
-| OpenJ9 release  | Release date        | JDK8 (LTS)| JDK9 | JDK10 | JDK11 (LTS) | JDK12 | JDK13 |
-|-----------------|---------------------|-----------|------|-------|-------------|-------|-------|
-| v0.8.0          | March 2018          | Yes       | No   |       |             |       |       |
-| v0.9.0          | August 2018 (\*1)   | Yes       | No   | Yes   |             |       |       |
-| v0.10.0         | September 2018 (\*1)| Yes       | No   | No    | Yes         |       |       |
-| v0.11.0         | October 2018 (\*1)  | Yes       | No   | No    | Yes         |       |       |
-| v0.12.0         | January 2019 (\*1)  | No (\*2)  | No   | No    | No (\*2)    | Yes   |       |
-| v0.13.0         | April 2019 (\*1)    | No (\*2)  | No   | No    | No (\*2)    | Yes   |       |
-| v0.14.0         | July 2019 (\*1)     | No (\*2)  | No   | No    | No (\*2)    | No    | Yes   |
+| OpenJ9 release  | Release date        | JDK8 (LTS)| JDK9 | JDK10 | JDK11 (LTS) | JDK12   | JDK13 |
+|-----------------|---------------------|-----------|------|-------|-------------|---------|-------|
+| v0.8.0          | March 2018          | Yes       | No   |       |             |         |       |
+| v0.9.0          | August 2018 (\*1)   | Yes       | No   | Yes   |             |         |       |
+| v0.10.0         | September 2018 (\*1)| Yes       | No   | No    | Yes         |         |       |
+| v0.11.0         | September 2018 (\*1)| No        | No   | No    | Yes(\*3)    |         |       |
+| v0.12.0         | October 2018 (\*1)  | Yes       | No   | No    | Yes         |         |       |
+| v0.13.0         | January 2019 (\*1)  | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |
+| v0.14.0         | March 2019 (\*1)    | No        | No   | No    | No          | Yes(\*3)|       |
+| v0.15.0         | April 2019 (\*1)    | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |
+| v0.16.0         | July 2019 (\*1)     | No (\*2)  | No   | No    | No (\*2)    | No      | Yes   |
 
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
@@ -57,6 +63,7 @@ supported by any open project.
 - (\*2): We fully expect that OpenJDK8 will have open community maintainers beyond January 2019,
 so we expect to be able to continue supporting JDK8 beyond that date. Until maintainers have been established
 we are unable to make a definitive support statement. This position is the same for JDK11 and all future "LTS" releases.
+- (\*3): These OpenJ9 releases are the feature releases that only support the new OpenJDK release.
 
 For any issues or limitations of an Eclipse OpenJ9 release, read the [release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/).
 

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -32,7 +32,7 @@ currently supported by the OpenJDK community. We are committed to accepting prob
 Eclipse OpenJ9 against a supported OpenJDK level, with fixes being delivered in each release of Eclipse OpenJ9.
 
 In order to track the OpenJDK 6 month release cadence, OpenJ9 also produces two releases a year that support only
-a single JDK level.  These releases will occur in March and September with the intention of only supporting
+a single JDK level.  These releases will occur in March and September with the intention of supporting only
 the corresponding new OpenJDK feature release (ie: 11, 12, ...).
 
 The following table summarizes which JDK levels are expected to be supported by which Eclipse OpenJ9 releases,
@@ -48,13 +48,12 @@ supported by any open project.
 |-----------------|---------------------|-----------|------|-------|-------------|---------|-------|
 | v0.8.0          | March 2018          | Yes       | No   |       |             |         |       |
 | v0.9.0          | August 2018 (\*1)   | Yes       | No   | Yes   |             |         |       |
-| v0.10.0         | September 2018 (\*1)| Yes       | No   | No    | Yes         |         |       |
-| v0.11.0         | September 2018 (\*1)| No        | No   | No    | Yes(\*3)    |         |       |
-| v0.12.0         | October 2018 (\*1)  | Yes       | No   | No    | Yes         |         |       |
-| v0.13.0         | January 2019 (\*1)  | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |
-| v0.14.0         | March 2019 (\*1)    | No        | No   | No    | No          | Yes(\*3)|       |
-| v0.15.0         | April 2019 (\*1)    | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |
-| v0.16.0         | July 2019 (\*1)     | No (\*2)  | No   | No    | No (\*2)    | No      | Yes   |
+| v0.10.0         | September 2018 (\*1)| No        | No   | No    | Yes(\*3)    |         |       |
+| v0.11.0         | October 2018 (\*1)  | Yes       | No   | No    | Yes         |         |       |
+| v0.12.0         | January 2019 (\*1)  | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |
+| v0.13.0         | March 2019 (\*1)    | No        | No   | No    | No          | Yes(\*3)|       |
+| v0.14.0         | April 2019 (\*1)    | No (\*2)  | No   | No    | No (\*2)    | Yes     |       |
+| v0.15.0         | July 2019 (\*1)     | No (\*2)  | No   | No    | No (\*2)    | No      | Yes   |
 
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**


### PR DESCRIPTION
From the mailing list:
---
Now that the 0.9.0 release is complete, it’s time to think about the schedule for future releases.
With OpenJDK’s new 6 month release cycle, new Java versions are released every 6 months.  With
JDK11’s September release fast approaching and followed closely after by the October JDK8 quarterly
update, there’s a lot of work to do!

What does this OpenJDK release landscape look like?

1) New versions of Java are released every 6 months: March and Sept.
2) Regular updates to existing releases happen quarterly: Jan, April, July & Oct.

What does OpenJ9 need to do?

OpenJ9 needs to at a minimum align with the quarterly updates to ensure critical fixes (including
security patches) are available in OpenJDK with OpenJ9 builds as soon as possible after the changes
appear in OpenJDK.  This would commit the project to at least 4 releases a year.

OpenJ9 should also aim to match the delivery of feature releases and not wait for them appear in the
quarterly update cycle.  This allows roughly a month for projects that are following the feature
releases to migrate before the next quarterly update.  This would commit the project to 2 additional
releases a year.

This would commit the project to 6 releases a year:
* 4 of them are quarterly updates and would include all supported JDK levels
* 2 of them (March & Sept) would be special releases that introduce a single new JDK level

We would work with the Adopt community to ensure that it is clear to users which OpenJ9 releases
should be built for each JDK level (ie: quarterly vs special releases).

Following this proposal, the next OpenJ9 release would be 0.10.0 in Sept and would only target JDK11.
The next OpenJ9 release would be 0.11.0 in Oct and would include the quarterly updates for JDK 8, 10, & 11.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>