### PR TITLE
Correct the doc about default DirectByteBuffer memory limit

### DIFF
--- a/docs/xxmaxdirectmemorysize.md
+++ b/docs/xxmaxdirectmemorysize.md
@@ -31,14 +31,13 @@ This Oracle Hotspot option sets a limit on the amount of memory that can be rese
 
     -XX:MaxDirectMemorySize<size>
 
-| Setting      |  Value                             | Default  |
-|--------------|------------------------------------|----------|
-|`<size>`      | *[1[k\|K\|m\|M\|g\|G] or greater]* | -        |
+| Setting      |  Value                             | Default                      |
+|--------------|------------------------------------|------------------------------|
+|`<size>`      | *[1[k\|K\|m\|M\|g\|G] or greater]* | Depends on maximum heap size |
 
 The value you choose is the limit on memory that can be reserved for all Direct Byte Buffers. If a value is set for this option, the sum of all Direct Byte Buffer sizes cannot exceed the limit. After the limit is reached, a new Direct Byte Buffer can be allocated only when enough old buffers are freed to provide enough space to allocate the new buffer.
 
-By default, the VM does not set a limit on how much memory is reserved for Direct Byte Buffers. A soft limit of 64 MB is set, which the VM automatically expands in 32 MB chunks, as required.
-
+By default, the VM limits the amount of heap memory used for Direct Byte Buffers to approximately 85% of the maximum heap size.
 
 
 


### PR DESCRIPTION
Default is ~85% of max heap size (previously, doc said a limit was not set).
https://github.com/eclipse/openj9-docs/issues/67

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>