### PR TITLE
Remove references to unsupported OpenJDK9 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,13 @@
 # Contributing to the documentation
 
 The user documentation is authored in markdown and built into HTML using [Mkdocs](http://www.mkdocs.org/), with a [mkdocs-material](https://github.com/squidfunk/mkdocs-material) theme. If you want to
-contribute to the documentation, we recommend that you install a local test environment for editing and previewing your changes.
+contribute to the documentation, we recommend that you install a local test environment for editing and previewing your changes. If you don't want to contribute to the documentation but you have a suggestion or want to report an error, please raise an issue in this repository. The following templates are available to help you provide the correct information for someone else to handle any changes:
+
+- [General documentation enhancements / ideas for improvements](https://github.com/eclipse/openj9-docs/issues/new?template=documentation-enhancement.md)
+- [Documentation errors or inaccuracies](https://github.com/eclipse/openj9-docs/issues/new?template=documentation-error.md)
+- [New content as a result of code changes at the Eclipse OpenJ9 repo](https://github.com/eclipse/openj9-docs/issues/new?template=new-documentation-change.md)
+
+Table of contents:
 
 - [Setting up a local MkDocs environment](#setting-up-a-local-mkdocs-environment)
 - [Editing the documentation](#editing-the-documentation)
@@ -125,10 +131,6 @@ If content is not marked it should apply to any platform.
 The user documentation supports the configuration, tuning, and diagnosis of the OpenJ9 VM in an OpenJDK version 8 or OpenJDK version 9 runtime. However, due to differences between the Java<sup>&trade;</sup> SE class libraries, specific options might apply only to one environment. The following icons are available to indicate where differences apply:
 
 - ![Java 8 icon](docs/cr/java8.png) - For content that applies only to an OpenJDK version 8.
-- ![Java 9 icon](docs/cr/java9.png) - For content that applies only to an OpenJDK version 9.
-- ![Java 9 and later icon](docs/cr/java9plus.png) -  For content that applies to an OpenJDK version 9 or later version.
-- ![Java 10 icon](docs/cr/java10.png) - For content that applies only to an OpenJDK version 10.
-- ![Java 10 and later icon](docs/cr/java10plus.png) -  For content that applies to an OpenJDK version 10 or later version.
 - ![Java 11 icon](docs/cr/java11.png) - For content that applies only to an OpenJDK version 11.
 - ![Java 11 and later icon](docs/cr/java11plus.png) -  For content that applies to an OpenJDK version 11 or later version.
 - ![Java 12 icon](docs/cr/java12.png) - For content that applies only to an OpenJDK version 12.
@@ -149,7 +151,7 @@ Here are some examples:
 ```
 
 ```
-![Start of content that applies only to Java 9 and later](cr/java9plus.png) This sentence applies only to Java 9 or later runtime environments that include the OpenJ9 VM. ![End of content that applies only to Java 9 or later](cr/java_close.png)
+![Start of content that applies only to Java 10 and later](cr/java10plus.png) This sentence applies only to Java 9 or later runtime environments that include the OpenJ9 VM. ![End of content that applies only to Java 10 and later](cr/java_close.png)
 ```
 
 ### Using images
@@ -183,7 +185,7 @@ Font-awesome icons are also used in option tables to indicate defaults. The foll
 
 Note that these require an extra `<span>`, which is used by screen readers.
 
-For examples that embed the ![Java 8 icon](docs/cr/java8.png) and ![Java 9 icon](docs/cr/java9.png) icons, see [Which OpenJDK version?](#which-openjdk-version?).
+For examples that embed Java version icons such as ![Java 8 icon](docs/cr/java8.png) and ![Java 12 and later icon](docs/cr/java12plus.png), see [Which OpenJDK version?](#which-openjdk-version?).
 
 ### Accessibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,26 +28,16 @@ Welcome to the user documentation for the Eclipse OpenJ9 virtual machine (VM).
 
 This user documentation supports the configuration, tuning, and diagnosis of the OpenJ9 VM in an OpenJDK runtime. However, due to differences between the Java SE class libraries, specific options might apply only to one Java SE version. Icons are used to indicate where differences apply. For example:
 
-![Start of content that applies only to Java 8 (LTS)](cr/java8.png) This sentence applies only to Java 8 binaries that include the OpenJ9 VM. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
+![Start of content that applies only to Java 8 (LTS)](cr/java8.png) This sentence applies only to Java 8 binaries that include the OpenJ9 VM. Icons for LTS releases are this colour. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
-![Start of content that applies only to Java 9 and later](cr/java9plus.png) This sentence applies only to Java 9 or later binaries that include the OpenJ9 VM. ![End of content that applies only to Java 9 or later](cr/java_close.png)
+![Start of content that applies only to Java 10 and later](cr/java10plus.png) This sentence applies only to Java 10 or later binaries that include the OpenJ9 VM. Icons for feature releases are this colour. ![End of content that applies only to Java 10 or later](cr/java_close.png)
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** As a usability aid, the icons for long term service (LTS) releases are a different colour from feature releases.
-
-The following table indicates which Java releases are LTS releases and which are feature releases:
-
-| Java SE version | LTS release                                                                    | Feature release                                                                    |
-|-----------------|:------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------:|
-| 8               | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |                                                                                    |
-| 9               |                                                                                | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
-| 10              |                                                                                | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
-| 11              | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> | |
-
+To see which Java releases are LTS releases and which are feature releases, and for information about release cadence, supported platforms, and build environments, see [Supported environments](openj9_support.md).
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Documentation to support OpenJ9 is still under construction. The current content covers
 some high level information about OpenJ9 components together with the command-line options and environment variables that you can use to configure the VM when you start your application. We expect further content to be contributed over time. Because OpenJ9 was contributed to the Eclipse Foundation by IBM, this content contains some links to additional information that forms part of the [IBM&reg; SDK, Java&trade; Technology Edition product documentation](https://www.ibm.com/support/knowledgecenter/SSYKE2/welcome_javasdk_family.html) in IBM Knowledge Center. That content supplements the documentation here until a more complete set of user documentation is available.
 
-We welcome contributions to the user documentation. If you would like to get involved, please read our [Contribution guidelines](https://github.com/eclipse/openj9-docs/blob/master/CONTRIBUTING.md).
+We welcome contributions to the user documentation. If you would like to get involved, please read our [Contribution guidelines](https://github.com/eclipse/openj9-docs/blob/master/CONTRIBUTING.md). If you spot any errors in the documentation, please raise an [issue](https://github.com/eclipse/openj9-docs/issues/new?template=documentation-error.md) at our GitHub repository.
 
 ## What is OpenJ9
 
@@ -66,8 +56,8 @@ This reference material provides information about the VM configuration and tuni
 You can obtain pre-built OpenJDK binaries from the AdoptOpenJDK project:
 
 - [OpenJDK8 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9)
-- [OpenJDK9 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk9&jvmVariant=openj9)
 - [OpenJDK10 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk10&jvmVariant=openj9)
+- [OpenJDK11 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9) (coming soon)
 
 ## Configuring your system
 
@@ -82,35 +72,19 @@ For normal operation, certain environment variables must be set at the operating
 
 ## Performance tuning
 
-OpenJ9 is configured to start with a set of default options that provide the optimal runtime environment for Java applications with typical workloads. However, if your application is atypical, you can improve performance by tuning the OpenJ9 VM. You can also improve performance by enabling hardware features or using specific APIs in your application code. Click the links to learn more about the following options:
+OpenJ9 is configured to start with a set of default options that provide the optimal runtime environment for Java applications with typical workloads. However, if your application is atypical, you can improve performance by tuning the OpenJ9 VM. You can also improve performance by enabling hardware features or using specific APIs in your application code.
 
-Choosing a garbage collection policy
-: J9 includes several garbage collection policies. To learn more about these policies and the types of application workload that can benefit from them, see [Garbage Collection](gc.md).
+### Garbage collection policies
+OpenJ9 includes several garbage collection policies. To learn more about these policies and the types of application workload that can benefit from them, see [Garbage Collection](gc.md).
 
-Improving startup times with class data sharing
-: You can share class data between running VMs, which can reduce the startup time for a VM once the cache has been created. For more information, see [Class Data Sharing](shrc.md).
+### Class data sharing
+You can share class data between running VMs, which can reduce the startup time for a VM once the cache has been created. For more information, see [Class Data Sharing](shrc.md).
 
+### Native data operations
+If your Java application manipulates native data, consider writing your application to take advantage of methods in the Data Access Accelerator API.
 
-
-<!-- These features not yet available in OpenJDK class libaries
-
-Using hardware compression acceleration devices
-: J9 can exploit hardware compression devices to reduce CPU consumption and shorten processing times.
-- For AIX and Linux systems, see Enabling hardware compression acceleration.
-- For IBM zEnterprise<sup>&reg;</sup> systems, see zEnterprise Data Compression.
-
-Exploiting Remote Direct Memory Access (RDMA)
-: High performance network infrastructure that supports Remote Direct Memory Access (RDMA) is designed to speed up communications between applications. : On Linux systems, existing Java socket applications can take advantage of RDMA-capable network adapters by using extensions to the Socket and ServerSocket APIs. For more information, see Java Sockets over Remote Direct Memory Access. Alternatively, you can write applications that use APIs in the jVerbs library to communicate directly over RDMA-capable infrastructure. See The jVerbs library.
--  On z/OS systems, J9 supports the use of the SMC-R protocol solution to enable TCP socket applications to transparently use RDMA. For more information, see Shared Memory Communication via RDMA.
-
-Exploiting Graphics Processing Units (GPU)
-: On Linux and Windows systems, you can improve the performance of your Java applications by offloading certain processing functions from your processor (CPU) to a graphics processing unit. For more information, see Exploiting Graphics Processing Units.-->
-
-Dealing with native data
-: If your Java application manipulates native data, consider writing your application to take advantage of methods in the Data Access Accelerator API.
-
-Optimizing your application for cloud deployments
-: To improve the performance of applications that run in the cloud, try setting the following tuning options:
+### Cloud optimizations  
+To improve the performance of applications that run in the cloud, try setting the following tuning options:
 
   - Use a shared classes cache (`-Xshareclasses -XX:SharedCacheHardLimit=200m -Xscmx60m`) with Ahead-Of-Time (AOT) compilation to improve your startup time. For more information, see [Class Data Sharing](shrc.md) and [AOT Compiler](aot.md).
   - Use the idle VM settings to maintain a smaller footprint, which can generate cost savings for cloud services that charge based on memory usage. The idle tuning mechanism detects when the VM is idle, releasing free memory pages to keep the footprint as small as possible and keep your running costs to a minimum. For more information, see [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md).

--- a/docs/openj9_defaults.md
+++ b/docs/openj9_defaults.md
@@ -92,11 +92,9 @@ The last 2 columns show whether the default setting can be changed by a command-
 
 The default value of `-Xmx` depends on the version of Java.
 
-Java 8
-: The value is half the available memory with a minimum of 16MB and a maximum of 512 MB.    
+- ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) The value is half the available memory with a minimum of 16MB and a maximum of 512 MB. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
-Java 9 and later
-: The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB
-    and a maximum value of 512 MB.
+
+- ![Start of content that applies only to Java 10 and later](cr/java10plus.png) The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB     and a maximum value of 512 MB. ![End of content that applies only to Java 10 and later](cr/java_close.png)
 
 *Available memory* is defined as being the smallest of two values: The real or *physical* memory or the *RLIMIT_AS* value.

--- a/docs/openj9_directories.md
+++ b/docs/openj9_directories.md
@@ -28,7 +28,7 @@ The following tables provide a quick reference to the OpenJ9 VM directory locati
 pages refer to the VM directory location as `<vm_dir>`.
 
 
-| Operating system            | Java 8                                  | Java 9 and later                          |
+| Operating system            | Java 8                                  | Java 10 and later                          |
 |-----------------------------|-----------------------------------------|-------------------------------------------|
 | AIX&reg;         | `<install_dir>/jre/lib/ppc[64]/default` | `<install_dir>/` |
 | Linux&trade;     | `<install_dir>/jre/lib/<arch>/default`  | `<install_dir>/` |

--- a/docs/xlp.md
+++ b/docs/xlp.md
@@ -26,7 +26,7 @@
 
 Requests the OpenJ9 VM to allocate the Java&trade; object heap and JIT code cache memory with large pages.
 
-![Start of content that applies only to Java 9 and later](cr/java9plus.png) This option is deprecated. Use the [`-Xlp:codecache`](xlpcodecache.md) and [`-Xlp:objectheap`](xlpobjectheap.md) options instead. ![End of content that applies only to Java 9 or later](cr/java_close.png)
+**Note:** This option is deprecated in all versions later than Java 8. Use the [`-Xlp:codecache`](xlpcodecache.md) and [`-Xlp:objectheap`](xlpobjectheap.md) options instead.
 
 If you use the [`-Xgc:preferredHeapBase`](xgc.md#preferredheapbase) option with `-Xlp`, the preferredHeapBase address must be a multiple of the large page size. If you specify an inaccurate heap base address, the heap is allocated with the default page size.
 

--- a/docs/xoptionsfile.md
+++ b/docs/xoptionsfile.md
@@ -39,8 +39,8 @@ The contents of the options file are recorded in the `ENVINFO` section of a Java
 
 At startup, the VM automatically adds `-Xoptionsfile=<path>/options.default` at the beginning of the command line, where `<path>` is the path to the VM directory.
 
-![Start of content that applies only to Java 8 (LTS)](cr/java8.png) `<path>` is the VM directory, as show in [Directory conventions](openj9_directories.md).  
-![Start of content that applies only to Java 9 and later](cr/java9plus.png) `<path>` is the `<java_home>/lib` directory, where `<java_home>` is the directory for your runtime environment.
+![Start of content that applies only to Java 8 (LTS)](cr/java8.png) `<path>` is the VM directory, as show in [Directory conventions](openj9_directories.md).![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)  
+![Start of content that applies only to Java 10 and later](cr/java10plus.png) `<path>` is the `<java_home>/lib` directory, where `<java_home>` is the directory for your runtime environment.![End of content that applies only to Java 10 or later](cr/java_close.png)
 
 The file `options.default` is empty but can be updated with any options that you want to specify at run time.
 


### PR DESCRIPTION
OpenJDK 10 supersedes OpenJDK9, which is no longer
supported by OpenJ9. Changes to the docs required:

- replace any "9 and later" icons with "10 and later".
- replace any mentions of OpenJDK9 with OpenJDK10
where appropriate.
- remove links to OpenJDK9 downloads.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>