### PR TITLE
Add OpenSSL performance tuning instructions

### DIFF
--- a/docs/djdknativecbc.md
+++ b/docs/djdknativecbc.md
@@ -1,0 +1,47 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Djdk.nativeCBC
+
+This option enables or disables OpenSSL native cryptographic support for the CBC algorithm.
+
+
+## Syntax
+
+        -Djdk.nativeCBC=[yes|no]
+
+| Setting           | value    | Default                                                                        |
+|-------------------|----------|:------------------------------------------------------------------------------:|
+| `-Djdk.nativeCBC` | yes      |                                                                                |
+| `-Djdk.nativeCBC` | no       | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+
+## Explanation
+
+OpenSSL support is not enabled by default. If you want to use this implementation to improve cryptographic performance, set this option to `yes` to enable support for the CBC algorithm.
+
+OpenSSL support is also available for the Digest and GCM algorithms. You can enable OpenSSL for all three algorithms with the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
+
+
+
+<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->

--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -1,0 +1,53 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Djdk.nativeCrypto
+
+This option controls the use of OpenSSL native cryptographic support.
+
+
+## Syntax
+
+        -Djdk.nativeCrypto=[yes|no]
+
+| Setting              | value    | Default                                                                        |
+|----------------------|----------|:------------------------------------------------------------------------------:|
+| `-Djdk.nativeCrypto` | yes      |                                                                                |
+| `-Djdk.nativeCrypto` | no       | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+
+## Explanation
+
+OpenSSL support is not enabled by default. If you want to use this implementation to improve cryptographic performance, set this option to `yes` to enable support for the Digest, CBC, and GCM algorithms.
+
+If you want to enable individual algorithms, use the following system properties:
+
+- [`-Djdk.nativeCBC`](djdknativecbc.md)
+- [`-Djdk.nativeDigest`](djdknativedigest.md)
+- [`-Djdk.nativeGCM`](djdknativegcm.md)
+
+
+
+
+
+<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -1,0 +1,48 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Djdk.nativeDigest
+
+This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
+
+
+## Syntax
+
+        -Djdk.nativeDigest=[yes|no]
+
+| Setting              | value    | Default                                                                        |
+|----------------------|----------|:------------------------------------------------------------------------------:|
+| `-Djdk.nativeDigest` | yes      |                                                                                |
+| `-Djdk.nativeDigest` | no       | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+
+## Explanation
+
+OpenSSL support is not enabled by default. If you want to use this implementation to improve cryptographic performance, set this option to `yes` to enable support for the Digest algorithm.
+
+OpenSSL support is also available for the GCM and CBC algorithms. You can enable OpenSSL for all three algorithms with the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
+
+
+
+
+<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->

--- a/docs/djdknativegcm.md
+++ b/docs/djdknativegcm.md
@@ -1,0 +1,48 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Djdk.nativeGCM
+
+This option enables or disables OpenSSL native cryptographic support for the GCM algorithm.
+
+
+## Syntax
+
+        -Djdk.nativeGCM=[yes|no]
+
+| Setting           | value    | Default                                                                        |
+|-------------------|----------|:------------------------------------------------------------------------------:|
+| `-Djdk.nativeGCM` | yes      |                                                                                |
+| `-Djdk.nativeGCM` | no       | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+
+## Explanation
+
+OpenSSL support is not enabled by default. If you want to use this implementation to improve cryptographic performance, set this option to `yes` to enable support for the GCM algorithm.
+
+OpenSSL support is also available for the Digest and CBC algorithms. You can enable OpenSSL for all three algorithms with the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
+
+
+
+
+<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -62,6 +62,40 @@ To improve the performance of applications that run in the cloud, try setting th
   - Use the idle VM settings to maintain a smaller footprint, which can generate cost savings for cloud services that charge based on memory usage. The idle tuning mechanism detects when the VM is idle, releasing free memory pages to keep the footprint as small as possible and keep your running costs to a minimum. For more information, see [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md).
   - Use the [-Xtune:virtualized](xtunevirtualized) option, which configures OpenJ9 for typical cloud deployments where VM guests are provisioned with a small number of virtual CPUs to maximize the number of applications that can be run. When enabled, OpenJ9 adapts its internal processes to reduce the amount of CPU consumed and trim down the memory footprint. These changes come at the expense of only a small loss in throughput.
 
+### Cryptographic operations
+
+![Start of content that applies only to Java 8 (LTS)](cr/java8.png)
+
+OpenJDK uses the in-built Java cryptographic implementation by default. However, native cryptographic implementations
+typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
+Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.1.x implementation is
+currently supported for OpenJDK 8 with OpenJ9 for the Digest, CBC, and GCM algorithms.
+
+OpenSSL support is not enabled by default. If you want to use this implementation to improve cryptographic performance, a number of system properties are
+available to enable it.
+
+If you want to enable native OpenSSL for all three supported algorithms, set the following system property on the command line when you start your application:
+
+```
+-Djdk.nativeCrypto=yes
+```
+
+Alternatively, you can enable one or more of the algorithms individually by using the following system properties:
+
+- For **digest**, set `-Djdk.nativeDigest=yes`
+- For **CBC**, set `-Djdk.nativeCBC=yes`
+- For **GCM**, set `-Djdk.nativeGCM=yes`
+
+
+To build a version of OpenJDK with OpenJ9 that includes OpenSSL v1.1.x support, follow the steps in our [detailed build instructions](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md).
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you obtain an OpenJDK with OpenJ9 build from [AdoptOpenJDK](https://adoptopenjdk.net/) that includes OpenSSL v1.1.x or build a version yourself that includes OpenSSL v1.1.x support, the following acknowledgements apply in accordance with the license terms:
+
+- *This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. (http://www.openssl.org/).*
+- *This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).*
+
+![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
+
 ## Runtime options
 
 Runtime options are specified on the command line and include system properties, standard options, nonstandard (**-X**) options, and **-XX** options. For a detailed list of runtime options, see [OpenJ9 command-line options](cmdline_specifying.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,10 @@ pages:
             - "-Dfile.encoding"                                                  : dfileencoding.md
 #           - "-Dibm.awt.mediumColor"                                            : dibmawtmediumcolor.md
 #           - "-Dil8n.vs"                                                        : dil8nvs.md
+            - "-Djdk.nativeCBC"                                                  : djdknativecbc.md
+            - "-Djdk.nativeCrypto"                                               : djdknativecrypto.md
+            - "-Djdk.nativeDigest"                                               : djdknativedigest.md
+            - "-Djdk.nativeGCM"                                                  : djdknativegcm.md
             - "-Djava.compiler"                                                  : djavacompiler.md
 #           - "-Dsun.rmi.transport.tcp.connectionPool"                           : dsunrmitransporttcpconnectionpool.md
             


### PR DESCRIPTION
For improving the performance of crypto
operations, added a section to explain how
to enable OpenSSL in an OpenJDK 8 with OpenJ9
binary.

Closes: #107

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>