### PR TITLE
Updates to migration topic for -XX:+UseNUMA and new aliases

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -38,40 +38,41 @@ You can use the following command-line options in OpenJ9, just as you did in Hot
 | [`-Xfuture`](xfuture.md)                                         | Turns on strict class-file format checks.                                                                                                    |
 | [`-Xint`](xint.md)                                               | Runs an application in interpreted-only mode.                                                                                                |
 | [`-Xmn`](xmn.md)                                                 | Sets the initial and maximum size of the new area when using -Xgcpolicy:gencon.                                                              |
-| [`-Xms`](xms.md)                                                 | Sets the initial size of the heap.                                                                                                           |
-| [`-Xmx`](xms.md)                                                 | Specifies the maximum size of the object memory allocation pool. (Equivalent to `-XX:MaxHeapSize`**<sup>1</sup>**)                           |
+| [`-Xms`](xms.md)                                                 | Sets the initial size of the heap. (Equivalent to `-XX:InitialHeapSize`)                                                                     |
+| [`-Xmx`](xms.md)                                                 | Specifies the maximum size of the object memory allocation pool. (Equivalent to `-XX:MaxHeapSize`)                                           |
 | [`-Xnoclassgc`](xclassgc.md)                                     | Disables class garbage collection (GC).                                                                                                      |
 | [`-Xrs`](xrs.md)                                                 | Prevents the OpenJ9 run time environment from handling signals.                                                                              |
-| [`-Xss`](xss.md)                                                 | Sets the thread stack size. (Equivalent to `-XX:ThreadStackSize`**<sup>2</sup>**)                                                            |
+| [`-Xss`](xss.md)                                                 | Sets the thread stack size. (Equivalent to `-XX:ThreadStackSize`)                                                                            |
 | [`-Xverify:mode`](xverify.md)                                    | Enables or disables the verifier.                                                                                                            |
 | [`-XX:[+|-]DisableExplicitGC`](xxdisableexplicitgc.md)           | Enables/disables `System.gc()` calls. (Alias for [`-Xdisableexplicitgc` / `-Xenableexplicitgc`](xenableexplicitgc.md))                       |
 | [`-XX:[+|-]HeapDumpOnOutOfMemory`](xxheapdumponoutofmemory.md)   | Enables/disables dumps on out-of-memory conditions.                                                                                          |
 | [`-XX:HeapDumpPath`](xxheapdumppath.md)                          | Specifies a directory for all VM dumps including heap dumps, javacores, and system dumps. (Alias for [`-Xdump:directory`](xdump/#syntax))    |
 | [`-XX:MaxDirectMemorySize`](xxmaxdirectmemorysize.md)            | Sets a limit on the amount of memory that can be reserved for all direct byte buffers.                                                       |
+| [`-XX:InitialHeapSize`](xxinitialheapsize.md)                    | Sets the initial size of the heap. (Alias for [`-Xms`](xms.md))                                                                              |
+| [`-XX:MaxHeapSize`    ](xxinitialheapsize.md)                    | Specifies the maximum size of the object memory allocation pool. (Alias for [`-Xmx`](xms.md))                                                |
+| [`-XX:ThreadStackSize`](xxthreadstacksize.md)                    | Sets the thread stack size. (Alias for [`-Xss`](xss.md))                                                                                     |
 | [`-XX:-UseCompressedOops`](xxusecompressedoops.md)               | Disables compressed references in 64-bit JVMs. (See also [`-Xcompressedrefs`](xcompressedrefs.md))                                           |
 
 ## Equivalent options
 
-These Hotspot command-line options have equivalents in OpenJ9 that are not specified in the same way, but perform the same function:
+These Hotspot command-line options have equivalents in OpenJ9 that are not specified in the same way, but perform a related function:
 
 | HotSpot Option          | OpenJ9 Option                                    | Usage                                                            |
 |-------------------------|--------------------------------------------------|------------------------------------------------------------------|                                                                        
-| `-Xcomp`                | [`-Xjit:count=0`](xjit.md#count)**<sup>3</sup>** | `-Xcomp` disables interpreted method invocations.                |
-| `-Xgc`                  | [`-Xgcpolicy`](xgcpolicy.md)**<sup>4</sup>**     | Configuring your garbage collection policy.                      |
+| `-Xcomp`                | [`-Xjit:count=0`](xjit.md#count)**<sup>1</sup>** | `-Xcomp` disables interpreted method invocations.                |
+| `-Xgc`                  | [`-Xgcpolicy`](xgcpolicy.md)**<sup>2</sup>**     | Configuring your garbage collection policy.                      |
 | `-XX:ParallelGCThreads` | [`-Xgcthreads`](xgcthreads.md)                   | Configure number of GC threads.                                  |
-| `-XX:+UseNUMA`          | [`-Xnuma:none`](xnumanone.md)**<sup>5</sup>**    | Controls non-uniform memory architecture (NUMA) awareness.       |
+| `-XX:+UseNUMA`          | [`-Xnuma:none`](xnumanone.md)**<sup>3</sup>**    | Controls non-uniform memory architecture (NUMA) awareness.       |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
 
-1. OpenJ9 does *not* recognise the alternative Hotspot option, `-XX:MaxHeapSize`.
+1. Hotspot uses `-Xcomp` to force compilation of methods on first invocation. Use `-Xjit` with `count`set to `0`. (`-Xjit` sets the number of times a method is called before it is compiled. Setting `count=0` forces the JIT compiler to compile everything on first execution.)
 
-2. OpenJ9 does *not* recognise the alternative Hotspot option, `-XX:ThreadStackSize`.
+2. Hotspot uses `-Xgc` to both select policies and configure them; OpenJ9 uses `-Xgcpolicy` to select policies, reserving `-Xgc` for configuration.
 
-3. Hotspot uses `-Xcomp` to force compilation of methods on first invocation. Use `-Xjit` with `count`set to `0`. (`-Xjit` sets the number of times a method is called before it is compiled. Setting `count=0` forces the JIT compiler to compile everything on first execution.)
-
-4. Hotspot uses `-Xgc` to both select policies and configure them; OpenJ9 uses `-Xgcpolicy` to select policies, reserving `-Xgc` for configuration.
-
-5. Hotspot uses `-XX:+UseNUMA` to turn *on* NUMA awareness, whereas OpenJ9 uses `-Xnuma:none` to turn it *off*.
+3. In Hotspot, NUMA awareness is turned off by default and is turned on by using the `-XX:+UseNUMA` option. Conversely, the OpenJ9 VM automatically enables NUMA awareness and uses `-Xnuma:none` to turn it *off*. 
+    - If you were previously using Hotspot in its default mode, you must now explicitly turn off NUMA awareness in OpenJ9.
+    - If you are used to using `-XX:+UseNUMA` in Hotspot, you no longer need to explicitly turn on NUMA awareness; it's on by default. 
 
 
 <!-- ==== END OF TOPIC ==== cmdline_migration.md ==== -->

--- a/docs/xxinitialheapsize.md
+++ b/docs/xxinitialheapsize.md
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 * Copyright (c) 2017, 2018 IBM Corp. and others
 *
 * This program and the accompanying materials are made
@@ -22,22 +22,15 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xnuma:none
+# -XX:InitialHeapSize / -XX:MaxHeapSize
 
-**(AIX&reg;, Linux&trade;, and Windows&trade; only)**
-
-Use this option to turn off non-uniform memory architecture (NUMA) awareness when using the balanced garbage collection policy.
-
-For workloads that do most of their work in one thread, or workloads that maintain a full heap, turning off NUMA awareness can improve performance.
+These Hotspot options for specifying heap size are recognized by OpenJ9 for compatibility. See [-Xms / -Xmx](xms.md) for details.
 
 ## Syntax
 
-        -Xnuma:none
+| Setting                     | Effect                  |
+|-----------------------------|-------------------------|
+| `-XX:InitialHeapSize<size>` | Set initial heap size   |
+| `-XX:MaxHeapSize<size>`     | Set maximum heap size   |
 
-## Default behavior
-
-NUMA awareness is enabled by default.
-
-
-
-<!-- ==== END OF TOPIC ==== xnumanone.md ==== -->
+<!-- ==== END OF TOPIC ==== xxinitialheapsize.md ==== -->

--- a/docs/xxthreadstacksize.md
+++ b/docs/xxthreadstacksize.md
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 * Copyright (c) 2017, 2018 IBM Corp. and others
 *
 * This program and the accompanying materials are made
@@ -22,22 +22,13 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xnuma:none
+# -XX:ThreadStackSize
 
-**(AIX&reg;, Linux&trade;, and Windows&trade; only)**
-
-Use this option to turn off non-uniform memory architecture (NUMA) awareness when using the balanced garbage collection policy.
-
-For workloads that do most of their work in one thread, or workloads that maintain a full heap, turning off NUMA awareness can improve performance.
+This Hotspot option to set the maximum Java thread stack size is recognized by OpenJ9 for compatibility. See [-Xss](xss.md) for details.
 
 ## Syntax
 
-        -Xnuma:none
-
-## Default behavior
-
-NUMA awareness is enabled by default.
-
-
-
-<!-- ==== END OF TOPIC ==== xnumanone.md ==== -->
+    -XX:ThreadStackSize<size>
+    
+    
+<!-- ==== END OF TOPIC ==== xxthreadstacksize.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,6 @@ site_description: Eclipse OpenJ9 documentation
 
 theme:
     name: material
-#    custom_dir: 'custom_theme'
     custom_dir: 'theme'
     palette:
       primary:  'cyan'
@@ -94,8 +93,8 @@ markdown_extensions:
 
 # Documentation layout
 
+# nav:   # "pages:" --> "nav:" for MkDocs 1.0
 pages:
-
 
     - "About"                                                                    : index.md
     - "Introduction"                                                             : introduction.md
@@ -283,9 +282,11 @@ pages:
             - "-XX:IdleTuningMinIdleWaitTime"                                    : xxidletuningminidlewaittime.md
             - "-XX:[+|-]IgnoreUnrecognizedVMOptions"                             : xxignoreunrecognizedvmoptions.md
             - "-XX:InitialRAMPercentage"                                         : xxinitialrampercentage.md
+            - "-XX:InitialHeapSize"                                              : xxinitialheapsize.md
             - "-XX:[+|-]InterleaveMemory"                                        : xxinterleavememory.md
             - "-XX:[+|-]LazySymbolResolution"                                    : xxlazysymbolresolution.md
             - "-XX:MaxDirectMemorySize"                                          : xxmaxdirectmemorysize.md
+            - "-XX:MaxHeapSize"                                                  : xxinitialheapsize.md              #redirect    
             - "-XX:MaxRAMPercentage"                                             : xxmaxrampercentage.md
             - "-XXnosuballoc32bitmem"                                            : xxnosuballoc32bitmem.md
             - "-XX:[+|-]PageAlignDirectMemory"                                   : xxpagealigndirectmemory.md
@@ -296,6 +297,7 @@ pages:
             - "-XX:ShareClassesEnableBCI"                                        : xxshareclassesenablebci.md
             - "-XX:SharedCacheHardLimit"                                         : xxsharedcachehardlimit.md
             - "-XX:-StackTraceInThrowable"                                       : xxstacktraceinthrowable.md
+            - "-XX:ThreadStackSize"                                              : xxthreadstacksize.md
             - "-XX:[+|-]UseCompressedOops"                                       : xxusecompressedoops.md
             - "-XX:[+|-]UseContainerSupport"                                     : xxusecontainersupport.md
             - "-XX:[+|-]UseNoGC"                                                 : xxusenogc.md


### PR DESCRIPTION
Amplify explanation of -XX:+UseNUMA/-Xnuma:none option.
Re Slack comment from Ashutosh Mehra

Add -XX:InitialHeapSize, -XX:MaxHeapSize, and -XX:ThreadStackSize
aliases (and new option topics).
Resolves #96

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>