### PR TITLE
[WIP] Container-aware options are on by default

### DIFF
--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -37,8 +37,9 @@ This option controls garbage collection processing with compaction when the stat
 | Setting                        | Effect  | Default                                                                            |
 |--------------------------------|---------|:----------------------------------------------------------------------------------:|
 | `-XX:+IdleTuningCompactOnIdle` | Enable  |                                                                                    |
-| `-XX:-IdleTuningCompactOnIdle` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-XX:-IdleTuningCompactOnIdle` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> (See **Note**) |
 
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If your application is running in a container, the default setting is `-XX:+IdleTuningCompactOnIdle`.
 
 If you enable this option, the OpenJ9 VM attempts to compact the object heap when the VM status is idle.
 

--- a/docs/xxidletuninggconidle.md
+++ b/docs/xxidletuninggconidle.md
@@ -37,8 +37,9 @@ This option can be used to reduce the memory footprint of the OpenJ9 VM when it 
 | Setting                   | Effect  | Default                                                                            |
 |---------------------------|---------|:----------------------------------------------------------------------------------:|
 | `-XX:+IdleTuningGcOnIdle` | Enable  |                                                                                    |
-| `-XX:-IdleTuningGcOnIdle` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-XX:-IdleTuningGcOnIdle` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> (See **Note**) |
 
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If your application is running in a container, the default setting is `-XX:+IdleTuningCompactOnIdle`.
 
 When the VM enters the idle state, enabling this option causes the VM to release free memory pages in the object heap without resizing the Java&trade; heap. The pages are reclaimed by the operating system, which reduces the physical memory footprint of the VM.
 

--- a/docs/xxusecontainersupport.md
+++ b/docs/xxusecontainersupport.md
@@ -26,7 +26,7 @@
 
 **(Linux&trade; only)**
 
-If your application is running in a container that imposes a memory limit, and you want the VM to allocate a larger fraction of memory to the Java heap, set the  `-XX:+UserContainerSupport` option.
+If your application is running in a container that imposes a memory limit, the VM allocates a larger fraction of memory to the Java heap. To turn off this behavior, set the `-XX:-UserContainerSupport` option on the command line.
 
 ## Syntax
 
@@ -36,8 +36,8 @@ If your application is running in a container that imposes a memory limit, and y
 
 | Setting                    | Effect  | Default                                                                            |
 |----------------------------|---------|:----------------------------------------------------------------------------------:|
-| `-XX:-UseContainerSupport` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
-| `-XX:+UseContainerSupport` | Enable  |                                                                                    |
+| `-XX:-UseContainerSupport` | Disable |                                                                                    |
+| `-XX:+UseContainerSupport` | Enable  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
 
 
 When using container technology, applications are typically run on their own and do not need to compete for memory. The OpenJ9 VM detects when it is running inside a container that imposes a memory limit, and if `-XX:+UserContainerSupport` is set, adjusts the maximum Java heap size appropriately.
@@ -54,7 +54,7 @@ The default heap size for containers takes affect only when the following condit
 
 1. The application is running in a container environment.
 2. The memory limit for the container is set.
-3. The `-XX:+UseContainerSupport` option is specified on the command line, which is expected to be the default in a future release.
+3. The `-XX:+UseContainerSupport` option is set, which is the default behavior.
 
 When [`-XX:MaxRAMPercentage`](xxmaxrampercentage.md) or [`-XX:InitialRAMPercentage`](xxinitialrampercentage.md) are used with `-XX:+UseContainerSupport`, the corresponding heap setting is determined based on the memory limit of the container. For example, to set the maximum heap size to 80% of the container memory, specify the following options:
 


### PR DESCRIPTION
To address docs issues #112 and #106

-XX:+UseContainerSupport is set by default if
the JVM is running in a container. This also
causes some idle tuning options to be enabled
by default.

Closes: #112
Closes: #106

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>