### PR TITLE
Correct the support statement for xgc:concurrentScavenge, by removing…

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -37,7 +37,7 @@ A special mode of the `gencon` policy is known as *Concurrent Scavenge* (`-Xgc:c
 - [Reducing Garbage Collection pause times with Concurrent Scavenge and the Guarded Storage Facility](https://developer.ibm.com/javasdk/2017/09/18/reducing-garbage-collection-pause-times-concurrent-scavenge-guarded-storage-facility/)
 - [How Concurrent Scavenge using the Guarded Storage Facility Works](https://developer.ibm.com/javasdk/2017/09/25/concurrent-scavenge-using-guarded-storage-facility-works/)
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Concurrent scavenge mode is available on Linux on IBM Z&reg; and the z/OS&reg; platform.
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Concurrent scavenge mode is available on Linux on x86-64, Linux on IBM Z&reg; and the z/OS&reg; platform.
 
 ## Other policies
 

--- a/docs/version0.11.md
+++ b/docs/version0.11.md
@@ -92,11 +92,11 @@ For nonpersistent caches or snapshots:
 When using container technology, applications are typically run on their own and do not need to compete for memory. If the VM detects that it is running in a container environment, and a memory limit for the container is set, the VM automatically adjusts the maximum default Java heap size.
 
 In earlier releases, this behavior was enabled by setting the `-XX:+UseContainerSupport` option. This setting is now the default. For more information
-about the Java heap size set for a container, see [-XX:\[+|-\]UseContainerSupport](xxusercontainersupport.md).
+about the Java heap size set for a container, see [-XX:\[+|-\]UseContainerSupport](xxusecontainersupport.md).
 
-## Pause-less garbage collection mode is now available on x86 platforms
+## Pause-less garbage collection mode is now available on Linux x86 platforms
 
-Pause-less garbage collection mode is aimed at large heap, response-time sensitive applications. When enabled, the VM attempts to reduce GC pause times. In earlier releases, pause-less garbage collection mode ([`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge)) was available only on IBM z14 hardware. This mode is now available on 64-bit x86 Linux and Windows platforms.
+Pause-less garbage collection mode is aimed at large heap, response-time sensitive applications. When enabled, the VM attempts to reduce GC pause times. In earlier releases, pause-less garbage collection mode ([`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge)) was available only on IBM z14 hardware. This mode is now available on 64-bit x86 Linux platforms.
 
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
 

--- a/docs/version0.11.md
+++ b/docs/version0.11.md
@@ -32,7 +32,7 @@ The following new features and notable changes since v.0.10.0 are included in th
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [Changes to the location of the default shared cache and cache snapshot directory](#changes-to-the-location-of-the-default-shared-cache-and-cache-snapshot-directory)
 - [New class data sharing suboptions](#new-class-data-sharing-suboptions)
 - [Container awareness in the OpenJ9 VM is now enabled by default](#container-awareness-in-the-openj9-vm-is-now-enabled-by-default)
-- [Pause-less garbage collection mode is now available on x86 platforms](#pause-less-garbage-collection-mode-is-now-available-on-x86-platforms)
+- [Pause-less garbage collection mode is now available on Linux x86 platforms](#pause-less-garbage-collection-mode-is-now-available-on-x86-platforms)
 - [You can now restrict identity hash codes to non-negative values](#you-can-now-restrict-identity-hash-codes-to-non-negative-values)
 - [Support for OpenJDK HotSpot options](#support-for-openjdk-hotspot-options)
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -51,7 +51,7 @@ Options that change the behavior of the Garbage Collector (GC).
 
 ### `concurrentScavenge`
 
-**(64-bit: not AIX or Linux on IBM Power Systems)**
+**(64-bit: Linux on x86, Linux on IBM Z&reg;, or z/OS&reg; only)**
 
         -Xgc:concurrentScavenge
 
@@ -66,7 +66,7 @@ Options that change the behavior of the Garbage Collector (GC).
     <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note: Linux on Z and z/OS**
 
     This option is supported on IBM z14&trade; hardware running the following software:
- 
+
     Operating systems:
 
     - z/OS V2R3


### PR DESCRIPTION
… Windows

This commit fixes the user docs for this issue: https://github.com/eclipse/openj9-docs/issues/126#issuecomment-433213295
(plus I fixed a link in the v0.11.0 topic)

[skip ci]

Fixes https://github.com/eclipse/openj9-docs/issues/126

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>