### PR TITLE
Fix link for xgc:concurrentScavenge

### DIFF
--- a/docs/version0.11.md
+++ b/docs/version0.11.md
@@ -32,7 +32,7 @@ The following new features and notable changes since v.0.10.0 are included in th
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [Changes to the location of the default shared cache and cache snapshot directory](#changes-to-the-location-of-the-default-shared-cache-and-cache-snapshot-directory)
 - [New class data sharing suboptions](#new-class-data-sharing-suboptions)
 - [Container awareness in the OpenJ9 VM is now enabled by default](#container-awareness-in-the-openj9-vm-is-now-enabled-by-default)
-- [Pause-less garbage collection mode is now available on Linux x86 platforms](#pause-less-garbage-collection-mode-is-now-available-on-x86-platforms)
+- [Pause-less garbage collection mode is now available on Linux x86 platforms](#pause-less-garbage-collection-mode-is-now-available-on-linux-x86-platforms)
 - [You can now restrict identity hash codes to non-negative values](#you-can-now-restrict-identity-hash-codes-to-non-negative-values)
 - [Support for OpenJDK HotSpot options](#support-for-openjdk-hotspot-options)
 


### PR DESCRIPTION
MkDocs generates anchors for h2's, so the link at the top of the v11 What's New needs to change to match the updated section heading

See issue: https://github.com/eclipse/openj9-docs/issues/128

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>