### PR TITLE
Correct 0.12.0 release line to say yes for 8 & 11

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -49,10 +49,10 @@ this table over time.
 | v0.9.0          | August 2018         | Yes       | Yes   |             |         |       |
 | v0.10.0         | September 2018      | No        | No    | Yes(\*3)    |         |       |
 | v0.11.0         | October 2018        | Yes       | No    | Yes         |         |       |
-| v0.12.0         | January 2019 (\*1)  | No (\*2)  | No    | No (\*2)    | Yes     |       |
+| v0.12.0         | January 2019 (\*1)  | Yes (\*2) | No    | Yes (\*2)   | No      |       |
 | v0.13.0         | March 2019 (\*1)    | No        | No    | No          | Yes(\*3)|       |
-| v0.14.0         | April 2019 (\*1)    | No (\*2)  | No    | No (\*2)    | Yes     |       |
-| v0.15.0         | July 2019 (\*1)     | No (\*2)  | No    | No (\*2)    | No      | Yes   |
+| v0.14.0         | April 2019 (\*1)    | Yes (\*2) | No    | Yes (\*2)   | Yes     |       |
+| v0.15.0         | July 2019 (\*1)     | Yes (\*2) | No    | Yes (\*2)   | No      | Yes   |
 
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**


### PR DESCRIPTION
It had incorrectly said "yes" only for JDK12 which won't ship until
March.  Update the "No" for JDK8 and JDK11 to say "Yes" based on the
statements by RedHat that they will step forward as the stewards of
JDK8 and by others to indicate they will help with backports.

I've left the `(*2)` note on both of those "Yes"s though.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>