### PR TITLE
Doc updates for "Enable bootstrap class sharing by default jdk11"

### DIFF
--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -32,10 +32,15 @@
 The following new features and notable changes since v.0.11.0 are delivered in the OpenJ9 code base:
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
+- [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default)
 
 
 ## Improved flexibility for managing the size of the JIT code cache
 
 The JIT code cache stores the native code of compiled Java&trade; methods. By default, the size of the code cache is 256 MB for a 64-bit VM and 64 MB for a 31/32-bit VM. In earlier releases the size of the code cache could be increased from the default value by using the `-Xcodecachetotal` command line option. In this release the size can also be decreased by using this option, with a minimum size of 2 MB. The size of the JIT code cache also affects the size of the JIT data cache, which holds metadata about compiled methods. If you use the `-Xcodecachetotal` option to manage the size of the code cache, the size of the data cache is adjusted by the same proportion. For more information, see [`-Xcodecachetotal`](codecachetotal.md).
+
+## Class data sharing is enabled by default
+
+For operating systems other than macOS, class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the -Xshareclasses option to change the default behavior. For more information, see [`Class Data Sharing`](shrc.md).
 
 <!-- ==== END OF TOPIC ==== version0.12.md ==== -->

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -41,6 +41,6 @@ The JIT code cache stores the native code of compiled Java&trade; methods. By de
 
 ## Class data sharing is enabled by default
 
-For operating systems other than macOS, class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the -Xshareclasses option to change the default behavior. For more information, see [`Class Data Sharing`](shrc.md).
+For operating systems other than macOS&reg;, class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [`Class Data Sharing`](shrc.md).
 
 <!-- ==== END OF TOPIC ==== version0.12.md ==== -->


### PR DESCRIPTION
See issue: https://github.com/eclipse/openj9-docs/issues/110

Update What's New topic

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>