### PR TITLE
Update pipeline script to find new Dockerfile

### DIFF
--- a/JenkinsFile_build_container.groovy
+++ b/JenkinsFile_build_container.groovy
@@ -40,7 +40,9 @@ timeout(time: 6, unit: 'HOURS') {
                         // Tag Regular build Containers with BUILD_NUMBER and 'latest'
                         TAGS = "-t ${NAMESPACE}/${CONTAINER_NAME}:${BUILD_NUMBER} -t ${NAMESPACE}/${CONTAINER_NAME}:latest"
                     }
-                    sh "docker build -f Dockerfile ${TAGS} ."
+                    dir('buildenv') {
+                        sh "docker build -f Dockerfile ${TAGS} ."
+                        }
                 }
 
                 if (params.ghprbPullId) {

--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Dockerfile Version 1.0
+# - implements virtualenv to isolate python3 from system python.
 
 FROM ubuntu:16.04
 MAINTAINER openj9.bot <openj9.bot@gmail.com> 


### PR DESCRIPTION
New dockerfile now located in /buildenv directory.
Pipeline script amended to build from this location.

Closes: #154

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>