### PR TITLE
Update OpenSSL support to include OpenJDK11

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -64,8 +64,6 @@ To improve the performance of applications that run in the cloud, try setting th
 
 ### Cryptographic operations
 
-![Start of content that applies only to Java 8 (LTS)](cr/java8.png)
-
 OpenJDK uses the in-built Java cryptographic implementation by default. However, native cryptographic implementations
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
 Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.1.x implementation is
@@ -86,14 +84,16 @@ You can turn off all three algorithms by setting the following system property o
 -Djdk.nativeCrypto=false
 ```
 
-To build a version of OpenJDK 8 with OpenJ9 that includes OpenSSL v1.1.x support, follow the steps in our [detailed build instructions](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md).
+To build a version of OpenJDK with OpenJ9 that includes OpenSSL v1.1.x support, follow the steps in our detailed build instructions:
+
+- [OpenJDK 8 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md).
+- [OpenJDK 11 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md).
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you obtain an OpenJDK with OpenJ9 build from [AdoptOpenJDK](https://adoptopenjdk.net/) that includes OpenSSL v1.1.x or build a version yourself that includes OpenSSL v1.1.x support, the following acknowledgements apply in accordance with the license terms:
 
 - *This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. (http://www.openssl.org/).*
 - *This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).*
 
-![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
 ## Runtime options
 

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -33,6 +33,7 @@ The following new features and notable changes since v.0.11.0 are delivered in t
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
 - [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default)
+- ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [OpenSSL is now supported for improved native cryptographic performance](#openssl-is-now-supported-for-improved-native-cryptographic-performance)
 
 
 ## Improved flexibility for managing the size of the JIT code cache
@@ -42,5 +43,15 @@ The JIT code cache stores the native code of compiled Java&trade; methods. By de
 ## Class data sharing is enabled by default
 
 For operating systems other than macOS&reg;, class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [`Class Data Sharing`](shrc.md).
+
+### OpenSSL is now supported for improved native cryptographic performance
+
+![Start of content that applies only to Java 11 (LTS)](cr/java11.png)
+
+OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols, which provides improved cryptographic performance compared to the in-built OpenJDK Java cryptographic implementation. The OpenSSL V1.1.x implementation is enabled by default and  supported for the Digest, CBC, and GCM algorithms. Binaries obtained from AdoptOpenJDK include OpenSSL v1.1.x (see Note). For more information about tuning the OpenSSL implementation, see [Performance tuning](introduction.md#cryptographic-operations).
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** OpenJDK 8 with OpenJ9 includes OpenSSL support since V0.11.0. Currently, OpenSSL is not bundled as part of the AdoptOpenJDK AIX binaries due to an unresolved problem.
+
+![End of content that applies only to Java 11 (LTS)](cr/java_close_lts.png)
 
 <!-- ==== END OF TOPIC ==== version0.12.md ==== -->


### PR DESCRIPTION
OpenSSL support is now implemented for
OpenJDK 11. The same options and settings apply.

https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/73

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>