### PR TITLE
Fix bugs and apply changes to -X options

### DIFF
--- a/docs/xenableexcessivegc.md
+++ b/docs/xenableexcessivegc.md
@@ -34,11 +34,10 @@ If excessive time is spent in the GC, the option returns `null` for an allocate 
 
 | Setting               | Effect            | Default                                                                            |
 |-----------------------|-------------------|:----------------------------------------------------------------------------------:|
-|`-Xenableexcessivegc`  | Enable exception  |                                                                                    |
-|`-Xdisableexcessivegc` | Disable exception | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+|`-Xenableexcessivegc`  | Enable exception  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
+|`-Xdisableexcessivegc` | Disable exception |                                                                                    |
 
 
 
 <!-- ==== END OF TOPIC ==== xenableexcessivegc.md ==== -->
 <!-- ==== END OF TOPIC ==== xdisableexcessivegc.md ==== -->
-

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -73,6 +73,7 @@ Options that change the behavior of the Garbage Collector (GC).
     Hypervisors:
 
     - IBM z/VM 6.4 with [APAR VM65987](http://www-01.ibm.com/support/docview.wss?uid=isg1VM65987)
+    - IBM z/VM 7.1
     - KVM solutions with QEMU 2.10 or later and minimum host kernel level 4.12 (for example, RHEL 7.5 with kernel level 4.14)
 
     If these requirements are not met, the option is ignored.


### PR DESCRIPTION
-Xenableexcessivegc has the wrong default set.
Change it to enabled by default.

-Xgc:concurrentScavenge for Linux on Z, z/VM 7.1
hypervisor support now available.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>