### PR TITLE
Remove Next / Previous buttons to fix bug

### DIFF
--- a/docs/stylesheets/oj9.css
+++ b/docs/stylesheets/oj9.css
@@ -155,9 +155,11 @@
 height 3rem;
 }
 */
+/*
 .md-footer-nav__inner.md-grid {
 margin-top: 5rem;
 }
+*/
 
 /* HEADER */
 
@@ -314,15 +316,16 @@ i.fa-chevron-circle-right {
 }
 */
 
+/*
 .md-footer-nav {
   background-color: white;
-/*  margin-top: 4rem;*/
   margin-top: -3.5rem;
 }
 
-.md-footer-nav__inner > a.md-footer-nav__link div { /* Previous and Next topic buttons */
+.md-footer-nav__inner > a.md-footer-nav__link div { 
   color: #1a1a1a;
 }
+
 
 .md-footer-nav__direction {
   color: #757575;
@@ -351,7 +354,7 @@ i.fa-chevron-circle-right {
 .md-footer-nav__direction {
   font-size: 1.3rem;
 }
-
+*/)
 
 
 /* DRAFT COMMENTS */

--- a/theme/base.html
+++ b/theme/base.html
@@ -203,9 +203,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               {% endblock %}
 -->
               <!-- This block was originally in the theme's 'footer.html' partial file. It has been moved here in part to resolve issues with the footer being too large. -->
-              {% block previous_next %}
+<!--
+			  {% block previous_next %}
                 {% include "partials/previous_next.html" %}
               {% endblock %}
+-->
             </article>
           </div>
         </div>

--- a/theme/partials/language.html
+++ b/theme/partials/language.html
@@ -24,8 +24,6 @@
 {% macro t(key) %}{{ {
   "language": "en",
   "edit.link.title": "Edit this page",
-  "footer.previous": "Previous",
-  "footer.next": "Next",
   "search.placeholder": "Search",
   "source.link.title": "Go to repository",
   "toc.title": "On this page ..."

--- a/theme/partials/language/en.html
+++ b/theme/partials/language/en.html
@@ -26,8 +26,6 @@
   "clipboard.copy": "Copy to clipboard",
   "clipboard.copied": "Copied to clipboard",
   "edit.link.title": "Edit this page in GitHub",
-  "footer.previous": "Previous",
-  "footer.next": "Next",
   "meta.comments": "Comments",
   "meta.source": "Source",
   "search.placeholder": "Search",


### PR DESCRIPTION
The next / previous buttons have a problem due
to the way we have implemented some of the topics.
Where we have related options, these still have their own
TOC entries but the content is implemented in a common
markdown file. For example: -Xminf and -Xmaxf are
both in topic xminf.md. A result of this is that
clicking "next" when you are in -Xmaxf takes you to
-Xmint instead of -Xmaxt.

Since most of our topics are either self contained
(E.g. javadump) or reference material (command options),
the next / previous buttons are somewhat superfluous.

This PR removes next/previous from the user documentation.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>