### PR TITLE
Idle-tuning is enabled by default in 0.12.0

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,11 +56,12 @@ You can share class data between running VMs, which can reduce the startup time 
 If your Java application manipulates native data, consider writing your application to take advantage of methods in the Data Access Accelerator API.
 
 ### Cloud optimizations  
-To improve the performance of applications that run in the cloud, try setting the following tuning options:
+To improve the performance of applications that run in containers, try setting the following tuning options:
 
   - Use a shared classes cache (`-Xshareclasses -XX:SharedCacheHardLimit=200m -Xscmx60m`) with Ahead-Of-Time (AOT) compilation to improve your startup time. For more information, see [Class Data Sharing](shrc.md) and [AOT Compiler](aot.md).
-  - Use the idle VM settings to maintain a smaller footprint, which can generate cost savings for cloud services that charge based on memory usage. The idle tuning mechanism detects when the VM is idle, releasing free memory pages to keep the footprint as small as possible and keep your running costs to a minimum. For more information, see [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md).
   - Use the [-Xtune:virtualized](xtunevirtualized) option, which configures OpenJ9 for typical cloud deployments where VM guests are provisioned with a small number of virtual CPUs to maximize the number of applications that can be run. When enabled, OpenJ9 adapts its internal processes to reduce the amount of CPU consumed and trim down the memory footprint. These changes come at the expense of only a small loss in throughput.
+
+  The OpenJ9 VM automatically detects when it is running in a docker container and uses a mechanism to detect when the VM is idle. When an idle state is detected, OpenJ9 runs a garbage collection cycle and releases free memory pages back to the operating system. The object heap is also compacted to make best use of the available memory for further application processing. For cloud services that charge based on memory usage, maintaining a small footprint can generate cost savings. For more information about tuning options that control this process, see [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md).
 
 ### Cryptographic operations
 

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -33,6 +33,7 @@ The following new features and notable changes since v.0.11.0 are delivered in t
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
 - [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default)
+- [Idle-tuning is enabled by default when OpenJ9 runs in a docker container](#idle-tuning-is-enabled-by-default-when-openj9-runs-in-a-docker-container)
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [OpenSSL is now supported for improved native cryptographic performance](#openssl-is-now-supported-for-improved-native-cryptographic-performance)
 - [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 - [`IBM_JAVA_OPTIONS` is deprecated](#ibm_java_options-is-deprecated)
@@ -54,6 +55,15 @@ The JIT code cache stores the native code of compiled Java&trade; methods. By de
 ### Class data sharing is enabled by default
 
 Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
+
+### Idle-tuning is enabled by default when OpenJ9 runs in a docker container
+
+In an earlier release, a set of idle-tuning options were introduced to manage the footprint of the Java heap when the OpenJ9 VM is in an idle state. These options could be set manually on the command line. In this release, the following two options are enabled by default when OpenJ9 is running in a container:
+
+- `-XX:[+|-]IdleTuningGcOnIdle`, which runs a garbage collection cycle and releases free memory pages back to the operating system when the VM state is set to idle.
+- `-XX:[+|-]IdleTuningCompactOnIdle`, which compacts the object heap to reduce fragmentation when the VM state is set to idle.
+
+By default, the VM must be idle for 180 seconds before the status is set to idle. To control the wait time before an idle state is set, use the [`-XX:IdleTuningMinIdleWaitTime`](xxidletuningminidlewaittime.md) option. To turn off idle detection, set the value to `0`.
 
 ### OpenSSL is now supported for improved native cryptographic performance
 

--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -26,23 +26,24 @@
 
 **(Linux&reg; only)**
 
-This option controls garbage collection processing with compaction when the status of the OpenJ9 VM is set to idle.
+This option controls garbage collection processing with compaction when the state of the OpenJ9 VM is set to idle.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
 ## Syntax
 
         -XX:[+|-]IdleTuningCompactOnIdle
 
-| Setting                        | Effect  | Default                                                                            |
-|--------------------------------|---------|:----------------------------------------------------------------------------------:|
-| `-XX:+IdleTuningCompactOnIdle` | Enable  |                                                                                    |
-| `-XX:-IdleTuningCompactOnIdle` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| Setting                        | Effect  | Default  | Default when running in a docker container                                 |
+|--------------------------------|---------|:--------:|:--------------------------------------------------------------------------:|
+| `-XX:+IdleTuningCompactOnIdle` | Enable  |  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
+| `-XX:-IdleTuningCompactOnIdle` | Disable |  <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>   |   |
 
+The default depends on whether or not the OpenJ9 VM is running in a container. As indicated in the table, when the VM is running in a container and the state is set to idle, the VM attempts to compact the object heap following a garbage collection cycle. The garbage collection cycle is controlled by the `-XX:+IdleTuningGcOnIdle` option, which is also enabled by default when the OpenJ9 VM is running inside a container.
 
-If you enable this option, the OpenJ9 VM attempts to compact the object heap when the VM status is idle.
+If your application is not running in a container and you want to enable compaction as part of the idle-tuning process, set the `-XX:+IdleTuningCompactOnIdle` option on the command line when you start your application.
 
-The `-XX:+IdleTuningCompactOnIdle` option can be used with the `-XX:+IdleTuningMinIdleWaitTime`. If a value for the `-XX:+IdleTuningMinIdleWaitTime` option is not explicitly specified, the VM sets a default value of 180 seconds. If you want the VM to subsequently attempt to release the free memory pages in the object heap, use the `-XX:+IdleTuningGcOnIdle` option.
+The `-XX:+IdleTuningCompactOnIdle` option can be used with the `-XX:+IdleTuningMinIdleWaitTime`, which controls the amount of time that the VM must be idle before an idle state is set. If a value for the `-XX:+IdleTuningMinIdleWaitTime` option is not explicitly specified, the VM sets a default value of 180 seconds.
 
 ## See also
 

--- a/docs/xxidletuninggconidle.md
+++ b/docs/xxidletuninggconidle.md
@@ -26,29 +26,27 @@
 
 **(Linux&reg; only)**
 
-This option can be used to reduce the memory footprint of the OpenJ9 VM when it is in an idle state.
+This option controls whether a garbage collection cycle takes place when the state of the OpenJ9 VM is set to idle.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
 ## Syntax
 
         -XX:[+|-]IdleTuningGcOnIdle
 
-| Setting                   | Effect  | Default                                                                            |
-|---------------------------|---------|:----------------------------------------------------------------------------------:|
-| `-XX:+IdleTuningGcOnIdle` | Enable  |                                                                                    |
-| `-XX:-IdleTuningGcOnIdle` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| Setting                   | Effect  | Default  | Default when running in a docker container                                 |
+|---------------------------|---------|:--------:|:--------------------------------------------------------------------------:|
+| `-XX:+IdleTuningGcOnIdle` | Enable  |  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
+| `-XX:-IdleTuningGcOnIdle` | Disable |  <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>   |   |
 
+The default depends on whether or not the OpenJ9 VM is running in a docker container. As indicated in the table, when the VM is running in a container and the state is set to idle, this option causes the VM to release free memory pages in the object heap without resizing the Java&trade; heap. The pages are reclaimed by the operating system, which reduces the physical memory footprint of the VM. In a container environment, the VM also attempts to compact the object heap before releasing memory by default, which is controlled by the `-XX:[+|-]IdleTuningCompactOnIdle` option.
 
-When the VM enters the idle state, enabling this option causes the VM to release free memory pages in the object heap without resizing the Java&trade; heap. The pages are reclaimed by the operating system, which reduces the physical memory footprint of the VM.
+If your application is not running in a container and you want to enable idle-tuning, set the `-XX:+IdleTuningGcOnIdle` option on the command line when you start your application.
 
-This option is used with `-XX:IdleTuningMinIdleWaitTime` and `-XX:IdleTuningMinFreeHeapOnIdle` . If values for these options are not explicitly specified, the VM sets the following defaults:
+When enabled, the `-XX:+IdleTuningGcOnIdle` option is used with the `-XX:IdleTuningMinIdleWaitTime` and `-XX:IdleTuningMinFreeHeapOnIdle` options. If values for these options are not explicitly specified, the VM sets the following defaults:
 
 -   `-XX:IdleTuningMinIdleWaitTime`=180
 -   `-XX:IdleTuningMinFreeHeapOnIdle`=0
-
-
-If you want the VM to attempt to compact the object heap before releasing memory, use the`-XX:+IdleTuningCompactOnIdle` option.
 
 ## See also
 

--- a/docs/xxidletuningminfreeheaponidle.md
+++ b/docs/xxidletuningminfreeheaponidle.md
@@ -47,9 +47,9 @@ If you set `-XX:IdleTuningMinFreeHeapOnIdle=10`, no more than 90% of the free me
 
 ## See also
 
-- [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md#xxidletuningminidlewaittime "When the VM is idle, this option controls the minimum length of time that the VM must be idle before the status of the VM is set to idle. Further tuning options control the compaction of the object heap and the release of free memory pages, which reduces the footprint of the VM.")
-- [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md#xx/|-/idletuningcompactonidle "This option controls garbage collection processing with compaction when the status of the VM is set to idle.")
-- [-XX:\[+|-\]IdleTuningGcOnIdle](xxidletuninggconidle.md#xx/|-/idletuninggconidle "This option can be used to reduce the memory footprint of the VM when it is in an idle state.")
+- [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md)
+- [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md)
+- [-XX:\[+|-\]IdleTuningGcOnIdle](xxidletuninggconidle.md)
 
 
 <!-- ==== END OF TOPIC ==== xxidletuningminfreeheaponidle.md ==== -->

--- a/docs/xxidletuningminidlewaittime.md
+++ b/docs/xxidletuningminidlewaittime.md
@@ -26,7 +26,7 @@
 
 ** (Linux&reg; only) **
 
-When the OpenJ9 VM is idle, this option controls the minimum length of time that the VM must be idle before the status of the VM is set to idle. Further tuning options control the compaction of the object heap and the release of free memory pages, which reduces the footprint of the VM.
+When the OpenJ9 VM is idle, this option controls the minimum length of time that the VM must be idle before the state of the VM is set to idle. When the state changes to idle, a garbage collection cycle runs, the object heap is compacted, and free memory pages are released back to the operating system, which reduces the footprint of the VM. Garbage collection and compaction are controlled by the `-XX:+IdleTuningGcOnIdle` and `-XX:+IdleTuningCompactOnIdle` options, which are enabled by default when the OpenJ9 VM is running inside a docker container.
 
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
@@ -34,11 +34,13 @@ When the OpenJ9 VM is idle, this option controls the minimum length of time that
 
         -XX:IdleTuningMinIdleWaitTime=<secs>
 
-| Setting     |  Value           | Default  |
-|-------------|------------------|----------|
-|`<secs>`     | *[0 or greater]* | 0        |
+| Setting     |  Value           |  Default  | Default when running in a docker container   |
+|-------------|------------------|-----------|----------------------------------------------|
+|`<secs>`     | *[0 or greater]* |    0      |                   180                        |
 
-The value used for `<secs>` specifies the minimum length of time in seconds that the VM is idle before the state is set to idle. Setting the value to 0 disables this feature, which causes the following idle tuning options to have no effect:
+The value used for `<secs>` specifies the minimum length of time in seconds that the VM is idle before the state is set to idle. Idle tuning is enabled by default when the OpenJ9 VM is running in a docker container and the VM is detected as idle for 180 seconds. 
+
+Setting the value to 0 disables this feature, which causes the following idle tuning options to have no effect:
 
 - `-XX:+IdleTuningCompactOnIdle`
 - `-XX:+IdleTuningGcOnIdle`
@@ -47,9 +49,9 @@ The value used for `<secs>` specifies the minimum length of time in seconds that
 
 ## See also
 
--   [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md#xx/|-/idletuningcompactonidle "This option controls garbage collection processing with compaction when the status of the VM is set to idle.")
--   [-XX:\[+|-\]IdleTuningGcOnIdle](xxidletuninggconidle.md#xx/|-/idletuninggconidle "This option can be used to reduce the memory footprint of the VM when it is in an idle state.")
--   [-XX:IdleTuningMinFreeHeapOnIdle](xxidletuningminfreeheaponidle.md#xxidletuningminfreeheaponidle "This option controls the percentage of free memory pages in the object heap that can be released when the VM is in an idle state.")
+-   [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md)
+-   [-XX:\[+|-\]IdleTuningGcOnIdle](xxidletuninggconidle.md)
+-   [-XX:IdleTuningMinFreeHeapOnIdle](xxidletuningminfreeheaponidle.md#xxidletuningminfreeheaponidle)
 
 
 


### PR DESCRIPTION
GC on idle and compact on idle are now enabled
by default when OpenJ9 detects that it is running
in a container and the VM enters an idle state.

Topics udpated to introduce the new behaviour.

Closes: #112

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>