### PR TITLE
Doc updates for changes to default shared classes cache dir permissions

### DIFF
--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -551,25 +551,25 @@ If a class name is passed to info class, the following information is shown abou
     This command is similar to the use of the `x/` command in gdb, including the use of defaults.
 
 
-### x/J [&lt;class_name&gt;|<0xaddr>]
+### x/J [`<class_name>`|`<0xaddr>`]
 
 : Displays information about a particular object, or all objects of a class. If `<class_name>` is supplied, all static fields with their values are shown, followed by all objects of that class with their fields and values. If an object address (in hex) is supplied, static fields for that object's class are not shown; the other fields and values of that object are printed along with its address.
 
     <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This command ignores the number of items and unit size passed to it by the `x/` command.
 
-### x/D <0xaddr>
+### x/D <`0xaddr`>
 
 : Displays the integer at the specified address, adjusted for the hardware architecture this dump file is from. For example, the file might be from a big endian architecture.
 
     <i class="fa fa-pencil-square-o"></i> This command uses the number of items and unit size passed to it by the `x/` command.
 
-### x/X <0xaddr>
+### x/X <`0xaddr`>
 
 : Displays the hex value of the bytes at the specified address, adjusted for the hardware architecture this dump file is from. For example, the file might be from a big endian architecture.
 
     <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This command uses the number of items and unit size passed to it by the `x/` command.
 
-### x/K <0xaddr>
+### x/K <`0xaddr`>
 
 : Where the size is defined by the pointer size of the architecture, this parameter shows the value of each section of memory. The output is adjusted for the hardware architecture this dump file is from, starting at the specified address. It also displays a module with a module section and an offset from the start of that module section in memory if the pointer points to that module section. If no symbol is found, it displays a "\*" and an offset from the current address if the pointer points to an address in 4KB (4096 bytes) of the current address. Although this command can work on an arbitrary section of memory, it is probably more useful on a section of memory that refers to a stack frame. To find the memory section of a thread stack frame, use the info thread command.
 

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -33,6 +33,7 @@ The following new features and notable changes since v.0.11.0 are delivered in t
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
 - [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default)
+- [Changes to default shared classes cache directory permissions (not Windows)](#changes-to-default-shared-classes-cache-directory-permissions-not-windows)
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [OpenSSL is now supported for improved native cryptographic performance](#openssl-is-now-supported-for-improved-native-cryptographic-performance)
 - [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 - [`IBM_JAVA_OPTIONS` is deprecated](#ibm_java_options-is-deprecated)
@@ -54,6 +55,14 @@ The JIT code cache stores the native code of compiled Java&trade; methods. By de
 ### Class data sharing is enabled by default
 
 Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
+
+### Changes to default shared classes cache directory permissions (not Windows)
+If you do not use the `cachDirPerm` suboption to specify permissions for a shared classes cache directory, and the cache directory is not the `/tmp/javasharedresources` default, the following changes apply:
+
+- When creating a new cache directory, the default permissions are now stricter.
+- If the cache directory already exists, permissions are now unchanged (previously, when a cache was opened using this directory, the permissions would be set to 0777).
+
+For more information, see [`-Xshareclasses`](xshareclasses.md#cachedirperm).
 
 ### OpenSSL is now supported for improved native cryptographic performance
 

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -120,7 +120,7 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
 
 ### `cacheDirPerm`
 
-: **(AIX, Linux, z/OS only)**
+: **(Not Windows)**
 
         -Xshareclasses:cacheDirPerm=<permission>
 
@@ -130,9 +130,18 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
 
 : If you set this suboption to 0000, the default directory permissions are used. If you set this suboption to 1000, the machine default directory permissions are used, but the sticky bit is enabled.
 
-: If the cache directory is the platform default directory, `/tmp/javasharedresources`, this suboption is ignored and the cache directory permissions are set to 777. If you do not set this suboption, the cache directory permissions are set to 777, for compatibility with earlier Java versions.
+: If the cache directory is the platform default directory, `/tmp/javasharedresources`, this suboption is ignored and the cache directory permissions are set to 0777.
 
-: On z/OS systems, permissions for existing cache directories are unchanged, to avoid generating RACF&reg; errors, which generate log messages.
+: If you do not set this suboption, the default permissions are used according to the following conditions:
+
+| Condition | Permissions |
+| ---------- | ----------- |
+| The cache directory is `/tmp/javasharedresources`. If this directory already exists with different permissions, the permissions are changed when the cache is opened.† | 0777 |
+| The cache directory is a new directory and you also specify the `groupAcess` suboption | 0770 |
+| The cache directory is a new directory and you do not specify the `groupAccess` suboption | 0700 |
+| The cache directory already exists and is not `/tmp/javasharedresources` | Unchanged |
+
+: †On z/OS systems, permissions for existing cache directories are unchanged, to avoid generating RACF&reg; errors, which generate log messages.
 
 : <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** It is good practice to explicitly set permissions for the cache directory when the defaults are not appropriate. See [Class data sharing: Best practices for using `-Xshareclasses`](shrc.md#best-practices-for-using-xshareclasses).
 


### PR DESCRIPTION
Add new section to What's New for 0.12.0, modify xshareclasses (cacheDirPerm section).
Also tweaked some markdown syntax in tool_jdmpview.

https://github.com/eclipse/openj9-docs/issues/178

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>