### PR TITLE
Doc updates for reverting shared classes enabled by default

### DIFF
--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -37,10 +37,13 @@ Memory footprint is reduced by sharing common classes between applications that 
 
 ## Enabling class data sharing
 
+You enable class data sharing by setting the `-Xshareclasses` option on the command line when you start your application. By default, OpenJ9 always shares both the bootstrap and application classes that are loaded by the default system class loader.
+
+<!--
   Class data sharing is enabled by default for bootstrap classes only, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, including the name and location of the default shared classes cache. Trace point `j9shr.2271` is activated if the default cache cannot be started, so you can enable this trace point to determine whether the default cache started successfully. You can treat the default cache like any other shared classes cache, for example you can print statistics for it, change the soft maximum limit size, or delete it. Note that if you have multiple VMs and you do not change the default shared classes behavior, the following applies:
 
 - If the VMs are from a single Java installation, they will share a single default cache.
-- If the VMs are from different Java installations, of the same Java release and installed by the same user, each VM checks whether the existing default shared cache in the cache directory is from the same Java installation as the VM. If not, the VM deletes that shared cache, then creates a new one. To avoid this situation, use `-Xshareclasses:cacheDir=<dir>` to specify a different cache directory for each Java installation.
+- If the VMs are from different Java installations, of the same Java release and installed by the same user, each VM checks whether the existing default shared cache in the cache directory is from the same Java installation as the VM. If not, the VM deletes that shared cache, then creates a new one. To avoid this situation, use `-Xshareclasses:cacheDir=<dir>` to specify a different cache directory for each Java installation. -->
 
 The [-Xshareclasses](xshareclasses.md) option is highly configurable, allowing you to specify where to create the cache, how much space to allocate for AOT code and more. You can also set the cache size by using the [-Xscmx](xscmx.md) option.
 

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -32,7 +32,7 @@
 The following new features and notable changes since v.0.11.0 are delivered in the OpenJ9 code base:
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
-- [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default)
+<!-- - [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default) -->
 - [Idle-tuning is enabled by default when OpenJ9 runs in a docker container](#idle-tuning-is-enabled-by-default-when-openj9-runs-in-a-docker-container)
 - [Changes to default shared classes cache directory permissions (not Windows)](#changes-to-default-shared-classes-cache-directory-permissions-not-windows)
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [OpenSSL is now supported for improved native cryptographic performance](#openssl-is-now-supported-for-improved-native-cryptographic-performance)
@@ -53,9 +53,9 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 The JIT code cache stores the native code of compiled Java&trade; methods. By default, the size of the code cache is 256 MB for a 64-bit VM and 64 MB for a 31/32-bit VM. In earlier releases the size of the code cache could be increased from the default value by using the `-Xcodecachetotal` command line option. In this release the size can also be decreased by using this option, with a minimum size of 2 MB. The size of the JIT code cache also affects the size of the JIT data cache, which holds metadata about compiled methods. If you use the `-Xcodecachetotal` option to manage the size of the code cache, the size of the data cache is adjusted by the same proportion. For more information, see [`-Xcodecachetotal`](xcodecachetotal.md).
 
-### Class data sharing is enabled by default
+<!-- ### Class data sharing is enabled by default
 
-Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
+Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md). -->
 
 ### Idle-tuning is enabled by default when OpenJ9 runs in a docker container
 


### PR DESCRIPTION
Comment out section in What's New for 0.12.0, comment out section about enabling in modify shrc.md, and replace with old content about setting -Xshareclasses.

https://github.com/eclipse/openj9-docs/issues/187

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>