### PR TITLE
Remove content for OpenJDK 10

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ This user documentation supports the configuration, tuning, and diagnosis of the
 
 ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) This sentence applies only to Java 8 binaries that include the OpenJ9 VM. Icons for LTS releases are this colour. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
-![Start of content that applies only to Java 10 and later](cr/java10plus.png) This sentence applies only to Java 10 or later binaries that include the OpenJ9 VM. Icons for feature releases are this colour. ![End of content that applies only to Java 10 or later](cr/java_close.png)
+![Start of content that applies only to Java 12 and later](cr/java12plus.png) This sentence applies only to Java 12 or later binaries that include the OpenJ9 VM. Icons for feature releases are this colour. ![End of content that applies only to Java 12 or later](cr/java_close.png)
 
 To see which Java releases are LTS releases and which are feature releases, and for information about release cadence, supported platforms, and build environments, see [Supported environments](openj9_support.md).
 
@@ -58,7 +58,6 @@ The online documentation provides information about the latest changes in the Ec
 You can obtain pre-built OpenJDK binaries from the AdoptOpenJDK project:
 
 - [OpenJDK8 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9)
-- [OpenJDK10 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk10&jvmVariant=openj9)
 - [OpenJDK11 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9)
 
 

--- a/docs/openj9_defaults.md
+++ b/docs/openj9_defaults.md
@@ -94,6 +94,6 @@ The default value of `-Xmx` depends on the version of Java.
 - ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) The value is half the available memory with a minimum of 16MB and a maximum of 512 MB. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
 
-- ![Start of content that applies only to Java 10 and later](cr/java10plus.png) The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB     and a maximum value of 512 MB. ![End of content that applies only to Java 10 and later](cr/java_close.png)
+- ![Start of content that applies only to Java 11 and later](cr/java11plus.png) The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. ![End of content that applies only to Java 11 and later](cr/java_close.png)
 
 *Available memory* is defined as being the smallest of two values: The real or *physical* memory or the *RLIMIT_AS* value.

--- a/docs/openj9_directories.md
+++ b/docs/openj9_directories.md
@@ -28,7 +28,7 @@ The following tables provide a quick reference to the OpenJ9 VM directory locati
 pages refer to the VM directory location as `<vm_dir>`.
 
 
-| Operating system | Java 8                                  | Java 10 and later                          |
+| Operating system | Java 8                                  | Java 11 and later                          |
 |------------------|-----------------------------------------|--------------------------------------------|
 | AIX&reg;         | `<install_dir>/jre/lib/ppc[64]/default` | `<install_dir>/` |
 | Linux&reg;       | `<install_dir>/jre/lib/<arch>/default`  | `<install_dir>/` |

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -114,43 +114,6 @@ minimum glibc version 2.12 are expected to function without problems.
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
-### OpenJDK 10
-
-OpenJDK10 binaries are supported on the minimum operating system levels shown in the following tables:
-
-
-| Linux                                 |  x64   |  ppc64le   | Z64  |
-|---------------------------------------|--------|------------|------|
-| Centos 6.9                            |   Y    |     Y      |  N   |
-| Centos 7.4                            |   Y    |     Y      |  N   |
-| Red Hat Enterprise Linux (RHEL) 6.9   |   Y    |     Y      |  Y   |
-| RHEL 7.4                              |   Y    |     Y      |  Y   |
-| SUSE Linux Enterprise Server (SLES) 12|   Y    |     Y      |  Y   |
-| Ubuntu 16.04                          |   Y    |     Y      |  Y   |
-| Ubuntu 18.04                          |   Y    |     Y      |  Y   |
-
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Not all of these distributions are tested, but Linux distributions that have a
-minimum glibc version 2.12 are expected to function without problems.
-
-| Windows                    |  x64   |
-|----------------------------|--------|
-| Windows 7 SP1              |   Y    |
-| Windows 8                  |   Y    |
-| Windows 8.1                |   Y    |
-| Windows 10                 |   Y    |
-| Windows Server 2012        |   Y    |
-| Windows Server 2012 R2     |   Y    |
-| Windows Server 2016        |   Y    |
-
-
-| AIX          |  ppc64   |
-|--------------|----------|
-| AIX 7.1 TL4  |    Y     |
-| AIX 7.2      |    Y     |
-
-When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
-
-
 ### OpenJDK 11
 
 OpenJDK11 binaries are supported on the minimum operating system levels shown in the following tables:
@@ -208,16 +171,6 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The minimum level of gcc supported for
 building OpenJDK 8 on Linux is v4.4.7. However, plans are in place to update the minimum supported level to at least v4.8 in the future.
-
-### OpenJDK 10
-
-| Platform                    | Operating system         |  Compiler                       |
-|-----------------------------|--------------------------|---------------------------------|
-| Linux x86 64-bit            | Ubuntu 16.04             | gcc 4.8.5                       |
-| Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 4.8.5                       |
-| Linux on IBM Z 64-bit       | Ubuntu 16.04             | gcc 4.8.5                       |
-| Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2013    |
-| AIX POWER BE 64-bit         | AIX 7.1 TL04             | xlc/C++ 13.1.3                  |
 
 ### OpenJDK 11
 

--- a/docs/xoptionsfile.md
+++ b/docs/xoptionsfile.md
@@ -40,7 +40,7 @@ The contents of the options file are recorded in the `ENVINFO` section of a Java
 At startup, the VM automatically adds `-Xoptionsfile=<path>/options.default` at the beginning of the command line, where `<path>` is the path to the VM directory.
 
 ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) `<path>` is the VM directory, as show in [Directory conventions](openj9_directories.md).![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)  
-![Start of content that applies only to Java 10 and later](cr/java10plus.png) `<path>` is the `<java_home>/lib` directory, where `<java_home>` is the directory for your runtime environment.![End of content that applies only to Java 10 or later](cr/java_close.png)
+![Start of content that applies only to Java 11 and later](cr/java11plus.png) `<path>` is the `<java_home>/lib` directory, where `<java_home>` is the directory for your runtime environment.![End of content that applies only to Java 11 or later](cr/java_close.png)
 
 The file `options.default` is empty but can be updated with any options that you want to specify at run time.
 


### PR DESCRIPTION
10 was a feature release that is no longer supported.
We left references in the documentation for 0.11.0
but want to remove them for 0.12.0.

Icons that indicate support from 10+ now show 11+
Supported environment tables for 10 also removed.
Links to OpenJDK 10 builds removed.

References to OpenJDK 10 in the release notes are
left as-is as these are a point in time statement.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>