### PR TITLE
Finalise 0.12.0 release topics

### DIFF
--- a/docs/legal.md
+++ b/docs/legal.md
@@ -38,7 +38,7 @@ See [Notices](https://github.com/eclipse/openj9-docs/blob/master/NOTICE.md)
 
 Eclipse OpenJ9 documentation is subject to the following copyright:
 
-    Copyright (c) 2017, 2018 IBM Corp.
+    Copyright (c) 2017, 2019 IBM Corp.
 
 ### Trademarks
 

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -49,7 +49,7 @@ this table over time.
 | v0.9.0          | August 2018         | Yes       | Yes   |             |         |          |
 | v0.10.0         | September 2018      | No        | No    | Yes(\*3)    |         |          |
 | v0.11.0         | October 2018        | Yes       | No    | Yes         |         |          |
-| v0.12.0         | January 2019 (\*1)  | Yes (\*2) | No    | Yes         |         |          |
+| v0.12.0         | January 2019        | Yes (\*2) | No    | Yes         |         |          |
 | v0.13.0         | March 2019 (\*1)    | No        | No    | No          | Yes(\*3)|          |
 | v0.14.0         | April 2019 (\*1)    | Yes (\*2) | No    | Yes (\*2)   | Yes     |          |
 | v0.15.0         | July 2019 (\*1)     | Yes (\*2) | No    | Yes (\*2)   | Yes     |          |
@@ -167,6 +167,7 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 | Linux on IBM Z&reg; 64-bit                  | Ubuntu 16.04              | gcc 7.4                         |
 | Windows x86 32-bit                          | Windows Server 2012 R2    | Microsoft Visual Studio 2010 SP1|
 | Windows x86 64-bit                          | Windows Server 2012 R2    | Microsoft Visual Studio 2010 SP1|
+| macOS x86 64-bit                            | OSX 10.11                 | xcode/clang 4.6.3 and 7.2.1     |
 | AIX POWER BE 64-bit                         | AIX 7.1 TL04              | xlc/C++ 13.1.3                  |
 
 ### OpenJDK 11

--- a/docs/version0.11.md
+++ b/docs/version0.11.md
@@ -40,10 +40,9 @@ The following new features and notable changes since v.0.10.0 are included in th
 
 ### Binaries and supported environments
 
-OpenJ9 release 0.11.0 provides limited support for the macOS&reg; platform on OpenJDK 11. Early builds of OpenJDK 11 with OpenJ9 on macOS are available at
-the AdoptOpenJDK project at the following link:  
+OpenJ9 release 0.11.0 provides limited support for the macOS&reg; platform on OpenJDK 11. Early builds of OpenJDK 11 with OpenJ9 on macOS are available at the AdoptOpenJDK project at the following link:  
 
-- [OpenJDK version 11](https://adoptopenjdk.net/nightly.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 
 Support for macOS on OpenJDK 8 is coming soon.
 

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -25,11 +25,7 @@
 
 # What's new in version 0.12.0
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This release is under development. For more information about the features that are expected in this release, read the [release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.12.0).
-
-<!--Use the line below for the final release notes and remove the one below that. Don't forget to add a download and full release changes at the bottom of the topic -->
-<!--The following new features and notable changes since v.0.11.0 are included in this release:-->
-The following new features and notable changes since v.0.11.0 are delivered in the OpenJ9 code base:
+The following new features and notable changes since v.0.11.0 are included in this release:
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
 <!-- - [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default) -->
@@ -37,15 +33,19 @@ The following new features and notable changes since v.0.11.0 are delivered in t
 - [Changes to default shared classes cache directory permissions (not Windows)](#changes-to-default-shared-classes-cache-directory-permissions-not-windows)
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [OpenSSL is now supported for improved native cryptographic performance](#openssl-is-now-supported-for-improved-native-cryptographic-performance)
 - [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
+- [RSA algorithm support for OpenSSL](#rsa-algorithm-support-for-openssl)
 - [`IBM_JAVA_OPTIONS` is deprecated](#ibm_java_options-is-deprecated)
 
 ## Features and changes
 
 ### Binaries and supported environments
 
-OpenJ9 release 0.12.0 provides limited support for the macOS&reg; platform on OpenJDK 8. Early builds of OpenJDK 8 with OpenJ9 on macOS are available at the AdoptOpenJDK project at the following link:
+OpenJ9 release 0.12.0 provides support for *OpenJDK 8 with OpenJ9* and *OpenJDK 11 with OpenJ9*. In this release support is extended to the 64-bit macOS&reg; platform on OpenJDK with OpenJ9.
 
-- [OpenJDK 8 with OpenJ9 macOS  x64](https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9)
+Builds for all platforms are available from the AdoptOpenJDK project at the following links:
+
+- [OpenJDK 8 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK 11 with OpenJ9](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
@@ -93,8 +93,16 @@ In Eclipse OpenJ9 V0.11.0, support was added for `-Xgc:concurrentScavenge` on Li
 
 For more information, see the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge) option.
 
+### RSA algorithm support for OpenSSL
+
+OpenSSL v1.1 support for the RSA algorithm is added in this release, providing improved cryptographic performance. OpenSSL support is enabled by default. If you want to turn off support for the RSA algorithm, set the [`-Djdk.nativeRSA`](djdknativersa.md) system property to `false`.
+
 ### `IBM_JAVA_OPTIONS` is deprecated
 
 The VM environment variable `IBM_JAVA_OPTIONS` is deprecated and is replaced by `OPENJ9_JAVA_OPTIONS`. `IBM_JAVA_OPTIONS` will be removed in a future release. For more information about the use of this variable, see the [general options](env_var.md#general-options) in [Environment variables](env_var.md).
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 V0.11.0 and V0.12.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.12/0.12.md).
 
 <!-- ==== END OF TOPIC ==== version0.12.md ==== -->


### PR DESCRIPTION
Updates to the what's new ahead of the 0.12.0
release to remove references to the release being
in progress. Update the support page to include
the macOS build system for 8 and remove the note
from 0.12.0 release to say it is in plan.

Late change to include RSA algorithm support added.

Pointed the 11 and 12 release topics at the
Adopt archive for macOS builds.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>