### PR TITLE
Add support for OpenSSL 1.0.2

### DIFF
--- a/docs/djdknativecbc.md
+++ b/docs/djdknativecbc.md
@@ -39,11 +39,9 @@ This option enables or disables OpenSSL native cryptographic support for the CBC
 
 ## Explanation
 
-OpenSSL support is enabled by default for the CBC,<!-- Digest,--> GCM, and RSA algorithm. If you want to turn off the CBC algorithm, set this option to `false`.
+OpenSSL support is enabled by default for the CBC, ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), GCM, and RSA algorithm. If you want to turn off the CBC algorithm, set this option to `false`.
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
 
-
-
-<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->
+<!-- ==== END OF TOPIC ==== djdknativecbc.md ==== -->

--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -38,15 +38,14 @@ This option controls the use of OpenSSL native cryptographic support.
 
 ## Explanation
 
-OpenSSL support is enabled by default for the <!--Digest,--> CBC, GCM, and RSA algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
+OpenSSL support is enabled by default for the ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), CBC, GCM, and RSA algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
 
 If you want to turn off the algorithms individually, use the following system properties:
 
 - [`-Djdk.nativeCBC`](djdknativecbc.md)
 - [`-Djdk.nativeGCM`](djdknativegcm.md)
 - [`-Djdk.nativeRSA`](djdknativersa.md)
+- ![Start of content that applies only to Java 12](cr/java12.png)[`-Djdk.nativeDigest`](djdknativedigest.md)![End of content that applies only to Java 12](cr/java_close.png)
 
-<!--- [`-Djdk.nativeDigest`](djdknativedigest.md)-->
 
-
-<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->
+<!-- ==== END OF TOPIC ==== djdknativecrypto.md ==== -->

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -24,12 +24,11 @@
 
 # -Djdk.nativeDigest
 
+![Start of content that applies only to Java 12](cr/java12.png)
+
 This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** Due to Github issue [#4530](https://github.com/eclipse/openj9/issues/4530), this option is disabled and has no effect. Currently, the Digest algorithm is not enabled by default.
-
-
-<!--## Syntax
+## Syntax
 
         -Djdk.nativeDigest=[true|false]
 
@@ -42,9 +41,9 @@ This option enables or disables OpenSSL native cryptographic support for the Dig
 
 OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the Digest algorithm, set this option to `false`.
 
-To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.-->
+To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
+
+![End of content that applies only to Java 12](cr/java_close.png)
 
 
-
-
-<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->
+<!-- ==== END OF TOPIC ==== djdknativedigest.md ==== -->

--- a/docs/djdknativegcm.md
+++ b/docs/djdknativegcm.md
@@ -38,11 +38,11 @@ This option enables or disables OpenSSL native cryptographic support for the GCM
 
 ## Explanation
 
-OpenSSL support is enabled by default for the CBC,<!-- Digest,--> GCM, and RSA algorithm. If you want to turn off the GCM algorithm, set this option to `false`.
+OpenSSL support is enabled by default for the CBC, ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), GCM, and RSA algorithm. If you want to turn off the GCM algorithm, set this option to `false`.
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
 
 
 
-<!-- ==== END OF TOPIC ==== dcomibmdbgmalloc.md ==== -->
+<!-- ==== END OF TOPIC ==== djdknativegcm.md ==== -->

--- a/docs/djdknativersa.md
+++ b/docs/djdknativersa.md
@@ -39,7 +39,7 @@ This option enables or disables OpenSSL native cryptographic support for the RSA
 
 ## Explanation
 
-OpenSSL support is enabled by default for the CBC,<!-- Digest,--> GCM, and RSA algorithm. If you want to turn off the RSA algorithm, set this option to `false`.
+OpenSSL support is enabled by default for the CBC, ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), GCM, and RSA algorithm. If you want to turn off the RSA algorithm, set this option to `false`.
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -70,14 +70,17 @@ To improve the performance of applications that run in containers, try setting t
 OpenJDK uses the in-built Java cryptographic implementation by default. However, native cryptographic implementations
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
 Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.1.x implementation is
-currently supported for the <!--Digest,--> CBC, GCM, and RSA algorithms.
+currently supported for the ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), CBC, GCM, and RSA algorithms.
 
-OpenSSL support is enabled by default for all these supported algorithms. If you want to limit support to specific algorithms, a number of
+![Start of content that applies only to Java 12](cr/java12.png)The OpenSSL V1.0.2 implementation is also supported for the Digest, CBC, GCM, and
+RSA algorithms. On Linux and AIX platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK. ![End of content that applies only to Java 12](cr/java_close.png)
+
+OpenSSL support is enabled by default for all supported algorithms. If you want to limit support to specific algorithms, a number of
 system properties are available for tuning the implementation.
 
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
-<!--- To turn off **digest**, set `-Djdk.nativeDigest=false`-->
+- ![Start of content that applies only to Java 12](cr/java12.png)To turn off **digest**, set `-Djdk.nativeDigest=false`![End of content that applies only to Java 12](cr/java_close.png)
 - To turn off **CBC**, set `-Djdk.nativeCBC=false`
 - To turn off **GCM**, set `-Djdk.nativeGCM=false`
 - To turn off **RSA**, set `-Djdk.nativeRSA=false`
@@ -88,7 +91,7 @@ You can turn off all the algorithms by setting the following system property on 
 -Djdk.nativeCrypto=false
 ```
 
-To build a version of OpenJDK with OpenJ9 that includes OpenSSL v1.1.x support, follow the steps in our detailed build instructions:
+To build a version of OpenJDK with OpenJ9 that includes OpenSSL support, follow the steps in our detailed build instructions:
 
 - [OpenJDK 8 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md).
 - [OpenJDK 11 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md).

--- a/docs/version0.13.md
+++ b/docs/version0.13.md
@@ -27,6 +27,8 @@
 
 The following new features and notable changes since v.0.12.1 are included in this release:
 
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- ![Start of content that applies only to Java 12](cr/java12.png) [Support for OpenSSL 1.0.2](#support-for-openssl-102)
 - [New Java&trade; process status tool](#new-java-process-status-tool)
 - [Writing a Java dump to STDOUT or STDERR](#writing-a-java-dump-to-stdout-or-stderr)
 - [Better diagnostic information for Linux systems that implement control groups](#better-diagnostic-information-for-linux-systems-that-implement-control-groups)
@@ -41,13 +43,29 @@ OpenJ9 release 0.13.0 supports OpenJDK 12, which is available from the AdoptOpen
 
 OpenJDK 12 with Eclipse OpenJ9 is not a long term support (LTS) release.
 
-Although it is possible to build an OpenJDK 8, or other versions, with OpenJ9 0.13.0, testing at the project is not complete and therefore support is not available.
+The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK community are for Eclipse OpenJ9 release 0.12.0. Features mentioned in these release notes are not available in these builds. Although it might be possible to build an OpenJDK 8 or OpenJDK 11 with OpenJ9 0.13.0, testing at the project is not complete and therefore support for any of these features is not available.
 
-To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md)
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Support for OpenSSL 1.0.2
+
+![Start of content that applies only to Java 12](cr/java12.png)
+
+OpenSSL cryptographic support is extended to include OpenSSL 1.0.2 for the Digest, CBC, GCM, and RSA algorithms. Support is enabled by default. On Linux and AIX platforms, the OpenSSL libraries are expected to be available on the system path. For more information about cryptographic acceleration with OpenSSL, see [Cryptographic operations](introduction.md#cryptographic-operations).
+
+In addition, support for the OpenSSL Digest algorithm is re-enabled in this release following the resolution of issue [#4530](https://github.com/eclipse/openj9/issues/4530).
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Warning:** Earlier versions of OpenJDK with OpenJ9 from the AdoptOpenJDK project bundle OpenSSL as part of the binary package. On Linux and AIX systems, OpenSSL is no longer bundled and the libraries are expected to be available on the system path.
+
+![End of content that applies only to Java 12](cr/java_close.png)
 
 ### New Java process status tool
 
-A Java process status tool (`jps`) is available for querying running Java processes. For more information, see [Java process status](tool_jps.md)
+![Start of content that applies only to Java 12](cr/java12.png)
+
+A Java process status tool (`jps`) is available for querying running Java processes. For more information, see [Java process status](tool_jps.md).
+
+![End of content that applies only to Java 12](cr/java_close.png)
 
 ### Writing a Java dump to STDOUT or STDERR
 
@@ -60,4 +78,5 @@ If you use control groups (cgroups) to manage resources on Linux systems, inform
 ## Full release information
 
 To see a complete list of changes between Eclipse OpenJ9 V0.12.1 and V0.13.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.13/0.13.md).
-<!-- ==== END OF TOPIC ==== cmdline_general.md ==== -->
+
+<!-- ==== END OF TOPIC ==== version0.13.md ==== -->


### PR DESCRIPTION
JDK 12 only

OpenSSL 1.0.2 is available on all platforms for Digest, CBC, GCM, and RSA.
On Linux and AIX you need to have it in your system path. For other
platforms the Adopt builds will bundle the 1.1.X library.

Digest re-enabled for 1.1.x

Closes: #188

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>