### PR TITLE
Updating the doc with new tag and spacing in javacore.

### DIFF
--- a/docs/dump_javadump.md
+++ b/docs/dump_javadump.md
@@ -196,30 +196,30 @@ NULL
 NULL           ------------------------------------------------------------------------
 2CICGRPINFO    subsystem : cpu
 2CICGRPINFO    cgroup name : /
-2CICGRPINFO		CPU Period : 100000 microseconds
-2CICGRPINFO		CPU Quota : Not Set
-2CICGRPINFO		CPU Shares : 1024
-2CICGRPINFO		Period intervals elapsed count : 0
-2CICGRPINFO		Throttled count : 0
-2CICGRPINFO		Total throttle time : 0 nanoseconds
+3CICGRPINFO	   CPU Period : 100000 microseconds
+3CICGRPINFO	   CPU Quota : Not Set
+3CICGRPINFO	   CPU Shares : 1024
+3CICGRPINFO	   Period intervals elapsed count : 0
+3CICGRPINFO	   Throttled count : 0
+3CICGRPINFO	   Total throttle time : 0 nanoseconds
 2CICGRPINFO    subsystem : cpuset
 2CICGRPINFO    cgroup name : /
-2CICGRPINFO		CPU exclusive : 1
-2CICGRPINFO		Mem exclusive : 1
-2CICGRPINFO		CPUs : 0-3
-2CICGRPINFO		Mems : 0
+3CICGRPINFO	   CPU exclusive : 1
+3CICGRPINFO	   Mem exclusive : 1
+3CICGRPINFO	   CPUs : 0-3
+3CICGRPINFO	   Mems : 0
 2CICGRPINFO    subsystem : memory
 2CICGRPINFO    cgroup name : /
-2CICGRPINFO		Memory Limit : Not Set
-2CICGRPINFO		Memory + Swap Limit : Not Set
-2CICGRPINFO		Memory Usage : 5363396608 bytes
-2CICGRPINFO		Memory + Swap Usage : 5363396608 bytes
-2CICGRPINFO		Memory Max Usage : 0 bytes
-2CICGRPINFO		Memory + Swap Max Usage : 0 bytes
-2CICGRPINFO		Memory limit exceeded count : 0
-2CICGRPINFO		Memory + Swap limit exceeded count : 0
-2CICGRPINFO		OOM Killer Disabled : 0
-2CICGRPINFO		Under OOM : 0
+3CICGRPINFO	   Memory Limit : Not Set
+3CICGRPINFO	   Memory + Swap Limit : Not Set
+3CICGRPINFO	   Memory Usage : 5363396608 bytes
+3CICGRPINFO	   Memory + Swap Usage : 5363396608 bytes
+3CICGRPINFO	   Memory Max Usage : 0 bytes
+3CICGRPINFO	   Memory + Swap Max Usage : 0 bytes
+3CICGRPINFO	   Memory limit exceeded count : 0
+3CICGRPINFO	   Memory + Swap limit exceeded count : 0
+3CICGRPINFO	   OOM Killer Disabled : 0
+3CICGRPINFO	   Under OOM : 0
 NULL           
 ```
 


### PR DESCRIPTION
The cgroup information in javacore is updated to have new tag
`3CICGRPINFO` for cgroup subsystems metrics. Earlier these
are having tag `2CICGRPINFO` (at the time of writing the doc).
The spacing is also adjusted to represent the current output
of the javacore.

Signed-off-by: bharathappali <bharath.appali@gmail.com>