### PR TITLE
Update JPS tool content to add icons for JDK 12

### DIFF
--- a/docs/tool_jps.md
+++ b/docs/tool_jps.md
@@ -24,6 +24,8 @@
 
 # Java process status
 
+![Start of content that applies only to Java 12](cr/java12.png)
+
 Use the `jps` tool to query running Java&trade; processes. The tool shows information for every Java process that is owned by the current user ID on the current host. The command syntax is as follows:
 
     jps [<options>]
@@ -53,7 +55,7 @@ For example:
     5462
     14332
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This tool is not supported and is subject to change or removal in future releases. Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation specific to OpenJ9. 
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This tool is not supported and is subject to change or removal in future releases. Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation specific to OpenJ9.
 
 The tool uses the Attach API, and has the following limitations:
 

--- a/docs/tool_migration.md
+++ b/docs/tool_migration.md
@@ -30,6 +30,8 @@ OpenJ9 provides the following tools, which might differ in behavior from the Hot
 
 #### Java process status (`jps`)
 
+![Start of content that applies only to Java 12](cr/java12.png)
+
 Displays information about running Java<sup>&trade;</sup> processes. The main differences from the HotSpot `jps` tool are as follows:
 
 - Runs on Windows&reg;, AIX&reg;, and z/OS&reg;
@@ -39,6 +41,7 @@ Displays information about running Java<sup>&trade;</sup> processes. The main di
 
 For more information, see [`Java process status`](tool_jps.md).
 
+![End of content that applies only to Java 12](cr/java_close.png)
 
 
 

--- a/docs/version0.13.md
+++ b/docs/version0.13.md
@@ -27,7 +27,7 @@
 
 The following new features and notable changes since v.0.12.1 are included in this release:
 
-- [New Java&trade; process status tool](#new-java-process-status-tool)
+- ![Start of content that applies only to Java 12](cr/java12.png) [New Java&trade; process status tool](#new-java-process-status-tool)
 - [Writing a Java dump to STDOUT or STDERR](#writing-a-java-dump-to-stdout-or-stderr)
 - [Better diagnostic information for Linux systems that implement control groups](#better-diagnostic-information-for-linux-systems-that-implement-control-groups)
 
@@ -46,6 +46,8 @@ Although it is possible to build an OpenJDK 8, or other versions, with OpenJ9 0.
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md)
 
 ### New Java process status tool
+
+![Start of content that applies only to Java 12](cr/java12.png)
 
 A Java process status tool (`jps`) is available for querying running Java processes. For more information, see [Java process status](tool_jps.md)
 


### PR DESCRIPTION
The JPS work involved adding launcher code to the
extensions repository. The only branch that will get
created in extensions is on JDK 12, so this content
must be marked as applicable only to JDK 12.

Icon markers added.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>