### PR TITLE
Extend platform support for software-based pauseless GC

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -106,7 +106,7 @@ A special mode of the `gencon` policy is known as *Concurrent Scavenge* (`-Xgc:c
     - [Reducing Garbage Collection pause times with Concurrent Scavenge and the Guarded Storage Facility](https://developer.ibm.com/javasdk/2017/09/18/reducing-garbage-collection-pause-times-concurrent-scavenge-guarded-storage-facility/)
     - [How Concurrent Scavenge using the Guarded Storage Facility Works](https://developer.ibm.com/javasdk/2017/09/25/concurrent-scavenge-using-guarded-storage-facility-works/)
 
-- **Software-based support: (Linux on x86-64 only)** With software-based support, *Concurrent Scavenge* can be enabled without any pre-requisite hardware although the performance throughput is not as good as hardware-based support.
+- **Software-based support: (Linux on x86-64, Linux on POWER LE, AIX&reg; on POWER&reg;)** With software-based support, *Concurrent Scavenge* can be enabled without any pre-requisite hardware although the performance throughput is not as good as hardware-based support.
 
 For more information about enabling Concurrent Scavenge, see the [-Xgc:concurrentScavenge](xgc.md#concurrentscavenge) option.
 
@@ -114,8 +114,8 @@ For more information about enabling Concurrent Scavenge, see the [-Xgc:concurren
 
 OpenJ9 has the following alternative GC policies:
 
-- `-Xgcpolicy:balanced` divides the Java heap into regions, which are individually managed to reduce the maximum pause time on large heaps and increase the efficiency of garbage collection. The aim of the policy is to avoid global collections by matching object allocation and survival rates. If you have problems with application pause times that are caused by global garbage collections, particularly compactions, this policy might improve application performance, particularly on large systems that have Non-Uniform Memory Architecture (NUMA) characteristics (x86 and POWER™ platforms).
-- `-Xgcpolicy:metronome` is designed for applications that require precise response times. Garbage collection occurs in small interruptible steps to avoid stop-the-world pauses. This policy is available only on x86 Linux and AIX&reg; platforms.
+- `-Xgcpolicy:balanced` divides the Java heap into regions, which are individually managed to reduce the maximum pause time on large heaps and increase the efficiency of garbage collection. The aim of the policy is to avoid global collections by matching object allocation and survival rates. If you have problems with application pause times that are caused by global garbage collections, particularly compactions, this policy might improve application performance, particularly on large systems that have Non-Uniform Memory Architecture (NUMA) characteristics (x86 and POWER platforms).
+- `-Xgcpolicy:metronome` is designed for applications that require precise response times. Garbage collection occurs in small interruptible steps to avoid stop-the-world pauses. This policy is available only on x86 Linux and AIX platforms.
 - `-Xgcpolicy:optavgpause` uses concurrent mark and sweep phases, which means that pause times are reduced when compared to optthruput, but at the expense of some performance throughput.
 - `-Xgcpolicy:optthruput` is optimized for throughput by disabling the concurrent mark phase, which means that applications will stop for long pauses while garbage collection takes place. You might consider using this policy when high application throughput, rather than short garbage collection pauses, is the main performance goal.
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -32,26 +32,26 @@ Options that change the behavior of the Garbage Collector (GC).
 
 ## Parameters
 
-| Parameter                                                       | Effect                                                                                                  |
-|-----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| [`concurrentScavenge`          ](#concurrentscavenge          ) | Enables a garbage collection (GC) mode with less pause times.|
-| [`dnssExpectedTimeRatioMaximum`](#dnssexpectedtimeratiomaximum) | Sets the maximum time to spend on GC of the nursery area.                                               |
-| [`dnssExpectedTimeRatioMinimum`](#dnssexpectedtimeratiominimum) | Sets the minimum time to spend on GC of the nursery area.                                               |
-| [`excessiveGCratio`            ](#excessivegcratio            ) | Sets a boundary value beyond which GC is deemed to be excessive.                                        |
-| [`minContractPercent`          ](#mincontractpercent          ) | Sets the minimum percentage of the heap that can be contracted at any given time.                       |
-| [`maxContractPercent`          ](#maxcontractpercent          ) | Sets the maximum percentage of the heap that can be contracted at any given time.                       |
-| [`overrideHiresTimerCheck`     ](#overridehirestimercheck     ) | Overrides GC operating system checks for timer resolution.                                              |
+| Parameter                                                       | Effect                                                                                                    |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| [`concurrentScavenge`          ](#concurrentscavenge          ) | Enables a garbage collection (GC) mode with less pause times.                                             |
+| [`dnssExpectedTimeRatioMaximum`](#dnssexpectedtimeratiomaximum) | Sets the maximum time to spend on GC of the nursery area.                                                 |
+| [`dnssExpectedTimeRatioMinimum`](#dnssexpectedtimeratiominimum) | Sets the minimum time to spend on GC of the nursery area.                                                 |
+| [`excessiveGCratio`            ](#excessivegcratio            ) | Sets a boundary value beyond which GC is deemed to be excessive.                                          |
+| [`minContractPercent`          ](#mincontractpercent          ) | Sets the minimum percentage of the heap that can be contracted at any given time.                         |
+| [`maxContractPercent`          ](#maxcontractpercent          ) | Sets the maximum percentage of the heap that can be contracted at any given time.                         |
+| [`overrideHiresTimerCheck`     ](#overridehirestimercheck     ) | Overrides GC operating system checks for timer resolution.                                                |
 | [`preferredHeapBase`           ](#preferredheapbase           ) | Sets a memory range for the Java&trade; heap. (AIX&reg;, Linux&reg;, macOS&reg;, and Windows&trade; only) |
-| [`scvNoAdaptiveTenure`         ](#scvnoadaptivetenure         ) | Turns off the adaptive tenure age in the generational concurrent GC policy.                             |
-| [`scvTenureAge`                ](#scvtenureage                ) | Sets the initial scavenger tenure age in the generational concurrent GC policy.                         |
-| [`tlhIncrementSize`            ](#tlhincrementsize            ) | Sets the size of the thread local heap (TLH)  increment                                      |
-| [`tlhInitialSize`              ](#tlhinitialsize              ) | Sets the initial size of the thread local heap                                               |
-| [`tlhMaximumSize`              ](#tlhmaximumsize              ) | Sets the maximum size of the thread local heap                                                      |
-| [`verboseFormat`               ](#verboseformat               ) | Sets the verbose GC format.                                                                  |
+| [`scvNoAdaptiveTenure`         ](#scvnoadaptivetenure         ) | Turns off the adaptive tenure age in the generational concurrent GC policy.                               |
+| [`scvTenureAge`                ](#scvtenureage                ) | Sets the initial scavenger tenure age in the generational concurrent GC policy.                           |
+| [`tlhIncrementSize`            ](#tlhincrementsize            ) | Sets the size of the thread local heap (TLH)  increment                                                   |
+| [`tlhInitialSize`              ](#tlhinitialsize              ) | Sets the initial size of the thread local heap                                                            |
+| [`tlhMaximumSize`              ](#tlhmaximumsize              ) | Sets the maximum size of the thread local heap                                                            |
+| [`verboseFormat`               ](#verboseformat               ) | Sets the verbose GC format.                                                                               |
 
 ### `concurrentScavenge`
 
-**(64-bit: Windows, Linux on x86, Linux on IBM Z&reg;, or z/OS&reg; only)**
+**(64-bit: Windows, Linux on x86, Linux on IBM Z&reg;, z/OS&reg;, Linux on POWER&reg; LE, or AIX)**
 
         -Xgc:concurrentScavenge
 


### PR DESCRIPTION
Update gc.md: "Software-based support"
and xgc.md: concurrentScavenge
Resolves #134

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>