### PR TITLE
Add new AdoptOpenJDK topic

### DIFF
--- a/docs/adoptopenjdk.md
+++ b/docs/adoptopenjdk.md
@@ -1,0 +1,28 @@
+
+
+# AdoptOpenJDK builds
+
+The AdoptOpenJDK community project provide pre-built binaries of OpenJDK with OpenJ9, which have been rigorously tested
+to meet expected quality standards. Binaries for the latest release of Eclipse OpenJ9 can be obtained from the
+following links:
+
+- [OpenJDK8 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK11 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK12 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk12&jvmVariant=openj9)
+
+Nightly builds of OpenJDK with OpenJ9 are also available from the project.
+
+## Supported platforms
+
+The community develop and maintain a build and test infrastructure for the OpenJDK source across a broad
+range of platforms. For information about the platforms and minimum operating system levels supported for the builds, see the AdoptOpenJDK [Platform support matrix](https://adoptopenjdk.net/supported_platforms.html).
+
+## Installation pre-requisites
+
+If you obtain binaries from the AdoptOpenJDK community, the following pre-requisites are required:
+
+- ![Start of content that applies only to Java 12](cr/java12.png) OpenJDK binaries for Linux and AIX platforms from the AdoptOpenJDK community no longer bundle the OpenSSL cryptographic library. The library is expected to be found on the system path. If you want to use OpenSSL cryptographic acceleration, you must install OpenSSL 1.0.2 or 1.1.X on your system. If the library is not found on the system path, the in-built Java crytographic implementation is used instead, which performs less well.  
+- ![Start of content that applies only to Java 8](cr/java8.png) On Linux systems, the `fontconfig.x86_64` package should be installed to avoid a `NullPointerException` error when the AWT font subsystem is initialized. Work is ongoing at the AdoptOpenJDK project to fix this issue for their OpenJDK binaries.
+
+
+<!-- ==== END OF TOPIC ==== adoptopenjdk.md ==== -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,11 +58,6 @@ Several versions of the documentation are available, covering all releases of Op
 - [Eclipse OpenJ9 website home page](https://www.eclipse.org/openj9)
 - [Eclipse OpenJ9 GitHub repository](https://github.com/eclipse/openj9)
 - [Eclipse Foundation OpenJ9 project page](https://projects.eclipse.org/projects/technology.openj9)
-
-You can obtain pre-built OpenJDK binaries from the AdoptOpenJDK project:
-
-- [OpenJDK8 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9)
-- [OpenJDK11 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9)
-- [OpenJDK12 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk12&jvmVariant=openj9)
+- [Pre-built binaries from the AdoptOpenJDK project](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9)
 
 <!-- ==== END OF TOPIC ==== index.md ==== -->

--- a/docs/openj9_newuser.md
+++ b/docs/openj9_newuser.md
@@ -81,14 +81,4 @@ If you are familiar with using HotSpot as part of an Oracle JDK or OpenJDK, you 
 
 ## Other differences
 
-This topic describes the differences between the HotSpot VM and the Eclipse OpenJ9 VM. Therefore, if you are currently using an OpenJDK with the default Hotspot VM and you want to switch to using an OpenJDK with the OpenJ9 VM, these are the only differences you might be concerned about. If however, you are using an Oracle JDK, you might want to learn about differences between other components that make up an Oracle JDK or an OpenJDK from the AdoptOpenJDK community.
-
-The following proprietary features are not available in an OpenJDK v8 binary:
-
-- **JavaFX:** This feature is deprecated by Oracle in Java SE 9 and is not available in Oracle JDK 11. The source code was contributed to OpenJDK under the OpenJFX project.
-- **Java plug-in and webstart:** These features were deprecated by Oracle in Java SE 9 and are not available in Oracke JDK 11. Oracle encourages developers to migrate to other solutions.
-- **T2K font library:** T2K is a proprietary native font library, which is licensed for use by Java 2D from a third party. OpenJDK uses the open FreeType font library as an alternative. The rendering of these fonts is almost identical and situations where there are differences are rare.
-
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Discussions are underway at the AdoptOpenJDK project to include OpenJFX and investigate the IcedTea-web project as a replacement for the Web Start capabilities.
-
-In addition to these proprietary features, there are currently no installers or updaters available for OpenJDK binaries from AdoptOpenJDK.
+This topic describes the differences between the HotSpot VM and the Eclipse OpenJ9 VM. Therefore, if you are currently using an OpenJDK with the default Hotspot VM and you want to switch to using an OpenJDK with the OpenJ9 VM, these are the only differences you might be concerned about. If however, you are using an Oracle JDK, you might want to learn about differences between other components that make up an Oracle JDK or an OpenJDK from the AdoptOpenJDK community. For more information, read the [Migration guide](https://adoptopenjdk.net/MigratingtoAdoptOpenJDKfromOracleJava.pdf).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,8 @@ markdown_extensions:
 pages:
 
     - "About"                                                                    : index.md
-    - "Introduction"                                                             : introduction.md
+    - "AdoptOpenJDK builds"                                                      : adoptopenjdk.md
+    - "Getting started"                                                          : introduction.md
     - "New to OpenJ9?"                                                           : openj9_newuser.md
     
     - "Release notes" :


### PR DESCRIPTION
For users who obtain binaries from Adopt, they need to be aware of: 

- platform support (link people to Adopts platform support matrix, which is slightly different from OpenJ9)
- Add the pre-reqs (1. OpenSSL no longer bundled on OpenJDK 12, so if they
need it they must install it locally. 2. On OpenJDK8 you need a fontconfig package to fix
a gap between Oracle licensed fonts and those used at Adopt.)

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>