### PR TITLE
Add missing whats new section

### DIFF
--- a/docs/version0.13.md
+++ b/docs/version0.13.md
@@ -30,6 +30,7 @@ The following new features and notable changes since v.0.12.1 are included in th
 - ![Start of content that applies only to Java 12](cr/java12.png) [New Java&trade; process status tool](#new-java-process-status-tool)
 - [Writing a Java dump to STDOUT or STDERR](#writing-a-java-dump-to-stdout-or-stderr)
 - [Better diagnostic information for Linux systems that implement control groups](#better-diagnostic-information-for-linux-systems-that-implement-control-groups)
+- [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 
 ## Features and changes
 
@@ -58,6 +59,15 @@ You can now write a Java dump file to STDOUT or STDERR by using the [`-Xdump`](x
 ### Better diagnostic information for Linux systems that implement control groups
 
 If you use control groups (cgroups) to manage resources on Linux systems, information about CPU and memory limits is now recorded in a Java dump file. This information is particularly important for applications that run in Docker containers, because when resource limits are set inside a container, the Docker Engine relies on cgroups to enforce the settings. If you are getting a Java `OutOfMemoryError` error because a container limit has been set on the amount of memory available to an application and this allocation is not sufficient, you can diagnose this problem from the Java dump file. You can find the cgroup information in the ENVINFO section. For sample output, see [Java dump (ENVINFO)](dump_javadump.md#envinfo).
+
+### Improved support for pause-less garbage collection
+
+Concurrent scavenge mode is now supported on the following platforms:
+
+- Linux on POWER LE
+- AIX
+
+For more information, see the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge) option.
 
 ## Full release information
 


### PR DESCRIPTION
Just spotted that we don't have an entry for extended pauseless GC
on Linux on POWER LE and AIX. Added.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>