### PR TITLE
Add/modify docs for new -XX:IgnoreUnrecognizedXXColonOptions option

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -50,6 +50,7 @@ You can use the following command-line options in OpenJ9, just as you did in Hot
 | [`-XX:[+|-]HeapDumpOnOutOfMemory`](xxheapdumponoutofmemory.md)   | Enables/disables dumps on out-of-memory conditions.                                                                                          |
 | [`-XX:HeapDumpPath`](xxheapdumppath.md)                          | Specifies a directory for all VM dumps including heap dumps, javacores, and system dumps. (Alias for [`-Xdump:directory`](xdump.md#syntax))    |
 | [`-XX:MaxDirectMemorySize`](xxmaxdirectmemorysize.md)            | Sets a limit on the amount of memory that can be reserved for all direct byte buffers.                                                       |
+| [`-XX:[+|-]IgnoreUnrecognizedVMOptions`](xxignoreunrecognizedvmoptions.md) | Specifies whether to ignore unrecognized top-level VM options |
 | [`-XX:InitialHeapSize`](xxinitialheapsize.md)                    | Sets the initial size of the heap. (Alias for [`-Xms`](xms.md))                                                                              |
 | [`-XX:MaxHeapSize`    ](xxinitialheapsize.md)                    | Specifies the maximum size of the object memory allocation pool. (Alias for [`-Xmx`](xms.md))                                                |
 | [`-XX:-UseCompressedOops`](xxusecompressedoops.md)               | Disables compressed references in 64-bit JVMs. (See also [`-Xcompressedrefs`](xcompressedrefs.md))                                           |

--- a/docs/openj9_newuser.md
+++ b/docs/openj9_newuser.md
@@ -6,7 +6,9 @@ The Eclipse OpenJ9 virtual machine (VM) implements the [Java Virtual Machine Spe
 
 ## Command-line options
 
-Although OpenJ9 implements its own command-line interface, many Hotspot options are recognized and accepted by the VM for compatibility. Any -XX options that are not recognized by the VM are ignored by default, which prevents an application failing to start. For a list of compatible options, see [Switching to OpenJ9](cmdline_migration.md) in the Command-line options section.
+Although OpenJ9 implements its own command-line interface, many Hotspot options are recognized and accepted by the VM for compatibility. Any `-XX:` options that are not recognized by the VM are ignored by default, which prevents an application failing to start. You can turn off this behavior with the [-XX:-IgnoreUnrecognizedXXColonOptions](xxignoreunrecognizedxxcolonoptions.md) option.
+
+For a list of compatible options, see [Switching to OpenJ9](cmdline_migration.md) in the Command-line options section.
 
 
 ## Garbage collection policies

--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -22,15 +22,21 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# Using -XX command-line options
 
-Java&trade; VM command-line options that are specified with `-XX:` are not checked for validity. If the VM does not recognize the option, the option is ignored. These options can therefore be used across different VM versions without ensuring a particular level of the VM.  If you want
-to turn off this behavior to test whether your -XX options are valid, use the [-XX:-IgnoreUnrecognizedXXColonOptions](xxignoreunrecognizedxxcolonoptions.md) option.
+# What's new in version 0.14.0
 
-For options that take a `<size>` parameter, add a suffix to the size value: "k" or "K" to indicate kilobytes, "m" or "M" to indicate megabytes, or "g" or "G" to indicate gigabytes.
+The following new features and notable changes since v.0.13.0 are included in this release:
 
-For example, to set the `-Xmx` value to 16 MB, you can specify `-Xmx16M`, `-Xmx16m`, `-Xmx16384K`, or `Xmx16384k` on the command line.
+- [New option for ignoring or reporting unrecognized -XX: options](#new-option-for-ignoring-or-reporting-unrecognized-xx-options)
 
+## Features and changes
 
+### New option for ignoring or reporting unrecognized -XX: options
 
-<!-- ==== END OF TOPIC ==== xx_jvm_commands.md ==== -->
+By default, unrecognized `-XX:` command-line options are ignored, which prevents an application failing to start. You can now use  `-XX:-IgnoreUnrecognizedXXColonOptions` to turn off this behavior, so that unrecognized `-XX:` options are reported instead. For more information, see [`-XX:\[+|-\]IgnoreUnrecognizedXXColonOptions`](xxignoreunrecognizedxxcolonoptions.md).
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 V0.13.0 and V0.14.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.14/0.14.md).
+
+<!-- ==== END OF TOPIC ==== version0.14.md ==== -->

--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -33,7 +33,7 @@ The following new features and notable changes since v.0.13.0 are included in th
 
 ### New option for ignoring or reporting unrecognized -XX: options
 
-By default, unrecognized `-XX:` command-line options are ignored, which prevents an application failing to start. You can now use  `-XX:-IgnoreUnrecognizedXXColonOptions` to turn off this behavior, so that unrecognized `-XX:` options are reported instead. For more information, see [`-XX:\[+|-\]IgnoreUnrecognizedXXColonOptions`](xxignoreunrecognizedxxcolonoptions.md).
+By default, unrecognized `-XX:` command-line options are ignored, which prevents an application failing to start. You can now use  `-XX:-IgnoreUnrecognizedXXColonOptions` to turn off this behavior, so that unrecognized `-XX:` options are reported instead. For more information, see [`-XX:[+|-]IgnoreUnrecognizedXXColonOptions`](xxignoreunrecognizedxxcolonoptions.md).
 
 ## Full release information
 

--- a/docs/xxignoreunrecognizedxxcolonoptions.md
+++ b/docs/xxignoreunrecognizedxxcolonoptions.md
@@ -1,0 +1,48 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:\[+|-\]IgnoreUnrecognizedXXColonOptions
+
+By default, any `-XX:` options that you specify on the command line are ignored if they are not recognized, which prevents an application failing to start. However, if you want to determine whether any of your `-XX:` options are unrecognized, you can turn off the behavior with this option. You might want to do this, for example, if you are switching to OpenJ9 from an alternative VM implementation where you are using `-XX:` options to tune the
+runtime environment.
+
+## Syntax
+
+        -XX:[+|-]IgnoreUnrecognizedXXColonOptions
+
+| Setting                            | Effect  | Default                                                                            |
+|------------------------------------|---------|:----------------------------------------------------------------------------------:|
+| `-XX:+IgnoreUnrecognizedXXColonOptions` | Enable  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-XX:-IgnoreUnrecognizedXXColonOptions` | Disable |                                                                               |
+
+When you specify `-XX:-IgnoreUnrecognizedXXColonOptions`, if you also specify a `-XX:` option that is not recognized, that option is reported and the VM does not start. For example:
+
+```
+JVMJ9VM007E Command-line option unrecognised: -XX:InvalidOption
+Error: Could not create the Java Virtual Machine.
+Error: A fatal exception has occurred. Program will exit.
+```
+
+
+<!-- ==== END OF TOPIC ==== xxignoreunrecognizedxxcolonoptions.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ pages:
     - "New to OpenJ9?"                                                           : openj9_newuser.md
     
     - "Release notes" :
+        - "Version 0.14.0"                                                       : version0.14.md
         - "Version 0.13.0"                                                       : version0.13.md
         - "Version 0.12.1"                                                       : version0.12.1.md
         - "Version 0.12.0"                                                       : version0.12.md        
@@ -282,6 +283,7 @@ pages:
             - "-XX:IdleTuningMinFreeHeapOnIdle"                                  : xxidletuningminfreeheaponidle.md
             - "-XX:IdleTuningMinIdleWaitTime"                                    : xxidletuningminidlewaittime.md
             - "-XX:[+|-]IgnoreUnrecognizedVMOptions"                             : xxignoreunrecognizedvmoptions.md
+            - "-XX:[+|-]IgnoreUnrecognizedXXColonOptions"                        : xxignoreunrecognizedxxcolonoptions.md            
             - "-XX:InitialRAMPercentage"                                         : xxinitialrampercentage.md
             - "-XX:InitialHeapSize"                                              : xxinitialheapsize.md
             - "-XX:[+|-]InterleaveMemory"                                        : xxinterleavememory.md


### PR DESCRIPTION
- Created new topic
- Updated content in https://eclipse.github.io/openj9-docs/openj9_newuser/ and https://eclipse.github.io/openj9-docs/xx_jvm_commands/, which talked about unrecognized options being ignored
- Created version0.14.md release notes topic, as this is the first update for the 0.14.0 release
- Also added -XX:IgnoreUnrecognizedVMOptions to https://eclipse.github.io/openj9-docs/cmdline_migration/, as it wasn't there but it's a HotSpot compatibility option, so probably should be

[skip ci]

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>