### PR TITLE
New support for ConcurrentScavenge GC mode

### DIFF
--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -27,13 +27,29 @@
 
 The following new features and notable changes since v.0.13.0 are included in this release:
 
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [New option for ignoring or reporting unrecognized -XX: options](#new-option-for-ignoring-or-reporting-unrecognized-xx-options)
+- [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 
 ## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.14.0 supports OpenJDK 8, 11, and 12. Binaries are available from the AdoptOpenJDK community at the following links:
+
+- [OpenJDK version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK version 12](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
 ### New option for ignoring or reporting unrecognized -XX: options
 
 By default, unrecognized `-XX:` command-line options are ignored, which prevents an application failing to start. You can now use  `-XX:-IgnoreUnrecognizedXXColonOptions` to turn off this behavior, so that unrecognized `-XX:` options are reported instead. For more information, see [`-XX:[+|-]IgnoreUnrecognizedXXColonOptions`](xxignoreunrecognizedxxcolonoptions.md).
+
+### Improved support for pause-less garbage collection
+
+Support for Concurrent scavenge mode is now extended to Linux on POWER BE architectures. For more information, see the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge) option.
 
 ## Full release information
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -51,7 +51,7 @@ Options that change the behavior of the Garbage Collector (GC).
 
 ### `concurrentScavenge`
 
-**(64-bit: Windows, Linux on x86, Linux on IBM Z&reg;, z/OS&reg;, Linux on POWER&reg; LE, or AIX)**
+**(64-bit: Windows, AIX, Linux (x86, POWER&reg;, or IBM Z&reg;), and z/OS&reg;)**
 
         -Xgc:concurrentScavenge
 


### PR DESCRIPTION
Support now extended to Linux on POWER BE architectures.
Updated the release topic for 0.14.0 and the xgc.md topic.

See https://github.com/eclipse/openj9/issues/5023

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>