### PR TITLE
Add support for OpenSSL 1.0.2 for Java 8 & 11

### DIFF
--- a/docs/djdknativecbc.md
+++ b/docs/djdknativecbc.md
@@ -39,7 +39,7 @@ This option enables or disables OpenSSL native cryptographic support for the CBC
 
 ## Explanation
 
-OpenSSL support is enabled by default for the CBC, ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), GCM, and RSA algorithm. If you want to turn off the CBC algorithm, set this option to `false`.
+OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the CBC algorithm, set this option to `false`.
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 

--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -38,14 +38,14 @@ This option controls the use of OpenSSL native cryptographic support.
 
 ## Explanation
 
-OpenSSL support is enabled by default for the ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), CBC, GCM, and RSA algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
+OpenSSL support is enabled by default for the Digest, CBC, GCM, and RSA algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
 
 If you want to turn off the algorithms individually, use the following system properties:
 
 - [`-Djdk.nativeCBC`](djdknativecbc.md)
 - [`-Djdk.nativeGCM`](djdknativegcm.md)
 - [`-Djdk.nativeRSA`](djdknativersa.md)
-- ![Start of content that applies only to Java 12](cr/java12.png)[`-Djdk.nativeDigest`](djdknativedigest.md)![End of content that applies only to Java 12](cr/java_close.png)
+- [`-Djdk.nativeDigest`](djdknativedigest.md)
 
 
 <!-- ==== END OF TOPIC ==== djdknativecrypto.md ==== -->

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -24,8 +24,6 @@
 
 # -Djdk.nativeDigest
 
-![Start of content that applies only to Java 12](cr/java12.png)
-
 This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
 
 ## Syntax
@@ -43,7 +41,6 @@ OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorith
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
-![End of content that applies only to Java 12](cr/java_close.png)
 
 
 <!-- ==== END OF TOPIC ==== djdknativedigest.md ==== -->

--- a/docs/djdknativegcm.md
+++ b/docs/djdknativegcm.md
@@ -38,7 +38,7 @@ This option enables or disables OpenSSL native cryptographic support for the GCM
 
 ## Explanation
 
-OpenSSL support is enabled by default for the CBC, ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), GCM, and RSA algorithm. If you want to turn off the GCM algorithm, set this option to `false`.
+OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the GCM algorithm, set this option to `false`.
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 

--- a/docs/djdknativersa.md
+++ b/docs/djdknativersa.md
@@ -39,7 +39,7 @@ This option enables or disables OpenSSL native cryptographic support for the RSA
 
 ## Explanation
 
-OpenSSL support is enabled by default for the CBC, ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), GCM, and RSA algorithm. If you want to turn off the RSA algorithm, set this option to `false`.
+OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the RSA algorithm, set this option to `false`.
 
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -70,17 +70,16 @@ To improve the performance of applications that run in containers, try setting t
 OpenJDK uses the in-built Java cryptographic implementation by default. However, native cryptographic implementations
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
 Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.1.x implementation is
-currently supported for the ![Start of content that applies only to Java 12](cr/java12.png)Digest![End of content that applies only to Java 12](cr/java_close.png), CBC, GCM, and RSA algorithms.
+currently supported for the Digest, CBC, GCM, and RSA algorithms.
 
-![Start of content that applies only to Java 12](cr/java12.png)The OpenSSL V1.0.2 implementation is also supported for the Digest, CBC, GCM, and
-RSA algorithms. On Linux and AIX platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK. ![End of content that applies only to Java 12](cr/java_close.png)
+The OpenSSL V1.0.2 implementation is also supported for the Digest, CBC, GCM, and RSA algorithms. On Linux and AIX platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK.
 
 OpenSSL support is enabled by default for all supported algorithms. If you want to limit support to specific algorithms, a number of
 system properties are available for tuning the implementation.
 
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
-- ![Start of content that applies only to Java 12](cr/java12.png)To turn off **digest**, set `-Djdk.nativeDigest=false`![End of content that applies only to Java 12](cr/java_close.png)
+- To turn off **Digest**, set `-Djdk.nativeDigest=false`
 - To turn off **CBC**, set `-Djdk.nativeCBC=false`
 - To turn off **GCM**, set `-Djdk.nativeGCM=false`
 - To turn off **RSA**, set `-Djdk.nativeRSA=false`

--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -28,6 +28,7 @@
 The following new features and notable changes since v.0.13.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Support for OpenSSL 1.0.2](#support-for-openssl-102)
 - [New option for ignoring or reporting unrecognized -XX: options](#new-option-for-ignoring-or-reporting-unrecognized-xx-options)
 - [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 
@@ -42,6 +43,14 @@ OpenJ9 release 0.14.0 supports OpenJDK 8, 11, and 12. Binaries are available fro
 - [OpenJDK version 12](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Support for OpenSSL 1.0.2
+
+OpenJ9 release 0.13.0 introduced support for OpenSSL 1.0.2 for Java 12. In this release, support is extended to Java 8 and Java 11. OpenSSL is enabled by default for the CBC, Digest, GCM, and RSA cryptographic algorithms. On Linux and AIX platforms, the OpenSSL libraries are expected to be available on the system path. For more information about cryptographic acceleration with OpenSSL, see [Cryptographic operations](introduction.md#cryptographic-operations).
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Support for the OpenSSL Digest algorithm on Java 8 and 11 is re-enabled in this release following the resolution of issue [#4530](https://github.com/eclipse/openj9/issues/4530).
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Warning:** Earlier versions of OpenJDK with OpenJ9 from the AdoptOpenJDK project bundle OpenSSL as part of the binary package. On Linux and AIX systems, OpenSSL is no longer bundled and the libraries are expected to be available on the system path.
 
 ### New option for ignoring or reporting unrecognized -XX: options
 


### PR DESCRIPTION
Add a section to the release topic, including warnings
about Adopt no longer bundling on Linux and AIX. Added
not about Digest re-enabled for Java 8 & 11.

Removed the Java 12 icons from all topics now that
support is available for 8 & 11, incuding the system properties.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>