### PR TITLE
Balanced GC requires seccomp=unconfined in Docker

### DIFF
--- a/docs/xgcpolicy.md
+++ b/docs/xgcpolicy.md
@@ -52,6 +52,8 @@ Specify the garbage collection policy that you want the OpenJ9 VM to use:
 
 : If you have problems with application pause times that are caused by global garbage collections, particularly compactions, this policy might improve application performance. If you are using large systems that have Non-Uniform Memory Architecture (NUMA) characteristics (x86 and POWER&trade; platforms only), the balanced policy might further improve application throughput.
 
+    <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you are using the balanced GC policy in a Docker container that uses the default `seccomp` Docker profile, you must start the container with `--security-opt seccomp=unconfined` to exploit NUMA characteristics. These options are not required if you are running in Kubernetes, because `unconfined` is set by default (see [Seccomp]( https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp)).
+
     For more information about this policy, including when to use it, see [Balanced Garbage Collection policy](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_balanced.html).
 
 #### Defaults and options


### PR DESCRIPTION
Unless seccomp is set to unconfined, Docker blocks
JVM system calls that leverage NUMA characteristics.

Docs updated to recommend setting unconfined when starting
Docker if Balanced is used in a Docker container.

Closes: #227

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>