### PR TITLE
Update support statement for 0.14.0

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -51,7 +51,7 @@ this table over time.
 | v0.11.0         | October 2018        | Yes       | Yes         |         |          |
 | v0.12.0         | January 2019        | Yes       | Yes         |         |          |
 | v0.13.0         | March 2019          | No        | No          | Yes(\*2)|          |
-| v0.14.0         | April 2019 (\*1)    | Yes       | Yes         | Yes     |          |
+| v0.14.0         | April 2019          | Yes       | Yes         | Yes     |          |
 | v0.15.0         | July 2019 (\*1)     | Yes       | Yes         | Yes     |          |
 | v0.16.0         | September 2019 (\*1)| No        | No          | No      | Yes(\*2) |
 


### PR DESCRIPTION
Remove the marker that indicates 0.14.0 is in plan,
ready for GA.

All other parts of this doc seem fine.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>