### PR TITLE
Add jstack (8,11,12) and update jps (8,11)

### DIFF
--- a/docs/tool_jps.md
+++ b/docs/tool_jps.md
@@ -22,7 +22,7 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# Java process status
+# Java process status (`jps`)
 
 ![Start of content that applies only to Java 12](cr/java12.png)
 
@@ -55,7 +55,7 @@ For example:
     5462
     14332
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This tool is not supported and is subject to change or removal in future releases. Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation specific to OpenJ9.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This tool is not supported and is subject to change or removal in future releases. Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation that is specific to OpenJ9.
 
 The tool uses the Attach API, and has the following limitations:
 

--- a/docs/tool_jstack.md
+++ b/docs/tool_jstack.md
@@ -1,0 +1,48 @@
+﻿<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# Java stack (`jstack`) tool
+
+Use the `jstack` tool to obtain Java stack traces and thread information for processes. The tool is similar to the HotSpot tool of the same name; the OpenJ9 version of `jstack` is an independent implementation, added for compatibility.
+
+The command syntax is as follows:
+
+    jstack <options>* <pid>*
+
+Where `<pid>*` is a list of process IDs. If none are supplied, the process IDs are read from `stdin`, which allows a user running a Bourne or equivalent shell to query all processes via `jps -q | jstack`. IDs of inactive processes are silently ignored. The output contains Java stacks and thread information of the specified processes (equivalent to the information provided in `java.lang.management.ThreadInfo`).
+
+The values for `<options>*` are as follows:
+
+- `-J`: supplies arguments to the Java VM that is running the `jstack` command. You can use multiple `-J` options, for example: `jstack -J-Xmx10m -J-Dcom.ibm.tools.attach.enable=yes`
+- `-p`: prints the system and agent properties of the process
+- `-l`: prints more verbose output, including information about locks
+- `-h`: prints help information
+
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
+
+- This tool is not supported and is subject to change or removal in future releases.
+- Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation that is specific to OpenJ9. For more information about differences, see [Switching to OpenJ9](tool_migration.md).
+
+<!-- ==== END OF TOPIC ==== tool_jstack.md ==== -->

--- a/docs/tool_migration.md
+++ b/docs/tool_migration.md
@@ -30,8 +30,6 @@ OpenJ9 provides the following tools, which might differ in behavior from the Hot
 
 #### Java process status (`jps`)
 
-![Start of content that applies only to Java 12](cr/java12.png)
-
 Displays information about running Java<sup>&trade;</sup> processes. The main differences from the HotSpot `jps` tool are as follows:
 
 - Runs on Windows&reg;, AIX&reg;, and z/OS&reg;
@@ -41,8 +39,16 @@ Displays information about running Java<sup>&trade;</sup> processes. The main di
 
 For more information, see [`Java process status`](tool_jps.md).
 
-![End of content that applies only to Java 12](cr/java_close.png)
+#### Java stack (`jstack`) tool
 
+Displays information about Java stack traces and thread information for processes. The main differences from the HotSpot `jstack` tool are as follows:
+
+- In the interests of security, the OpenJ9 implementation of `jstack` prints only information about local processes that are owned by the current user.
+- Printing data for core dumps is not supported. Use the [Dump viewer](tool_jdmpview.md) instead.
+- There is no `-m` option. Printing data for native stack frames is not supported.
+- There is no `-F` option to force a dump, although this might be accomplished using `kill -QUIT <pid>` on some platforms.
+
+For more information, see [`jstack`](tool_jstack.md).
 
 
 <!-- ==== END OF TOPIC ==== tools_migration.md ==== -->

--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -31,6 +31,8 @@ The following new features and notable changes since v.0.13.0 are included in th
 - [Support for OpenSSL 1.0.2](#support-for-openssl-102)
 - [New option for ignoring or reporting unrecognized -XX: options](#new-option-for-ignoring-or-reporting-unrecognized-xx-options)
 - [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
+- [New Java stack (`jstack`) tool for obtaining stack traces and thread information](#new-jstack-tool-for-obtaining-stack-traces-and-thread-information)
+- [New Java process status (`jps`) tool](#new-jps-tool)
 
 ## Features and changes
 
@@ -59,6 +61,15 @@ By default, unrecognized `-XX:` command-line options are ignored, which prevents
 ### Improved support for pause-less garbage collection
 
 Support for Concurrent scavenge mode is now extended to Linux on POWER BE architectures. For more information, see the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge) option.
+
+### New jstack tool for obtaining stack traces and thread information
+
+For compatibility with the reference implementation, OpenJ9 now includes an independent implementation of the `jstack` tool. To learn how to use the tool and
+about any differences compared to the HotSpot tool of the same name, see [Java stack tool](tool_jstack.md).
+
+### New jps tool
+
+OpenJ9 release 0.13.0 introduced support for the `jps` tool for Java 12. In this release, support is added for Java 8 and 11. The `jps` tool can be used to  query running Java processes. For more information, see [Java process status](tool_jps.md).
 
 ## Full release information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -313,7 +313,8 @@ pages:
         - "Dump viewer"                                                           : tool_jdmpview.md
         - "Trace formatter"                                                       : tool_traceformat.md
         - "Option builder"                                                        : tool_builder.md
-        - "Java process status"                                                   : tool_jps.md
+        - "Java process status (jps)"                                             : tool_jps.md
+        - "Java stack (jstack) tool"                                              : tool_jstack.md
         - "Switching to OpenJ9"                                                   : tool_migration.md        
 
         


### PR DESCRIPTION
- New tools topic for jstack
- New section for jstack in the release topic
- Updated to Tools "Switching to OpenJ9" to describe differences to
  HotSpot jstack

- Add jps to release topic for 8 & 11 (12 was in 0.13.0)
- Remove icons from jps content that specify Java 12 only.

Closes: #225

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>