### PR TITLE
Add option for JVMTI watched field performance

### DIFF
--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -33,6 +33,7 @@ The following new features and notable changes since v.0.13.0 are included in th
 - [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 - [New Java stack (`jstack`) tool for obtaining stack traces and thread information](#new-jstack-tool-for-obtaining-stack-traces-and-thread-information)
 - [New Java process status (`jps`) tool](#new-jps-tool)
+- [New experimental option to improve the performance of JVMTI watched fields](#new-experimental-option-to-improve-the-performance-of-jvmti-watched-fields)
 - [New option to prevent a network query being used to determine host name and IP address](#new-option-to-prevent-a-network-query-being-used-to-determine-host-name-and-ip-address)
 - [Changes to the shared classes cache generation number](#changes-to-the-shared-classes-cache-generation-number)
 
@@ -50,7 +51,7 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 ### Support for OpenSSL 1.0.2
 
-OpenJ9 release 0.13.0 introduced support for OpenSSL 1.0.2 for Java 12. In this release, support is extended to Java 8 and Java 11. OpenSSL is enabled by default for the CBC, Digest, GCM, and RSA cryptographic algorithms. On Linux and AIX platforms, the OpenSSL libraries are expected to be available on the system path. For more information about cryptographic acceleration with OpenSSL, see [Cryptographic operations](introduction.md#cryptographic-operations).
+OpenJ9 release 0.13.0 introduced support for OpenSSL 1.0.2 for Java 12. In this release, support is extended to Java 8 and Java 11. OpenSSL is enabled by default for the CBC, Digest, GCM, and RSA cryptographic algorithms. On Linux@reg; and AIX@reg; platforms, the OpenSSL libraries are expected to be available on the system path. For more information about cryptographic acceleration with OpenSSL, see [Cryptographic operations](introduction.md#cryptographic-operations).
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Support for the OpenSSL Digest algorithm on Java 8 and 11 is re-enabled in this release following the resolution of issue [#4530](https://github.com/eclipse/openj9/issues/4530).
 
@@ -62,7 +63,7 @@ By default, unrecognized `-XX:` command-line options are ignored, which prevents
 
 ### Improved support for pause-less garbage collection
 
-Support for Concurrent scavenge mode is now extended to Linux on POWER BE architectures. For more information, see [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge).
+Support for Concurrent scavenge mode is now extended to Linux on POWER@reg; BE architectures. For more information, see [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge).
 
 ### New jstack tool for obtaining stack traces and thread information
 
@@ -72,6 +73,11 @@ about any differences compared to the HotSpot tool of the same name, see [Java s
 ### New jps tool
 
 OpenJ9 release 0.13.0 introduced support for the `jps` tool for Java 12. In this release, support is added for Java 8 and 11. The `jps` tool can be used to  query running Java processes. For more information, see [Java process status](tool_jps.md).
+
+### New experimental option to improve the performance of JVMTI watched fields
+
+The [`-XX:[+|-]JITInlineWatches`](xxjitinlinewatches.md) option is introduced in this release. When enabled, the option turns on experimental
+JIT operations that are intended to improve the performance of JVMTI watched fields. This option is currently supported only on Windows@reg; and Linux on x86 platforms.
 
 ### New option to prevent a network query being used to determine host name and IP address
 

--- a/docs/xxjitinlinewatches.md
+++ b/docs/xxjitinlinewatches.md
@@ -1,0 +1,43 @@
+﻿<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:\[+|-\]JITInlineWatches
+
+**(x86: Linux&reg; and Windows&reg; only)**
+
+This option controls JIT operations that relate to JVMTI watched fields.
+
+## Syntax
+
+        -XX:[+|-]JITInlineWatches
+
+| Setting                 | Effect  | Default                                                                            |
+|-------------------------|---------|:----------------------------------------------------------------------------------:|
+| `-XX:+JITInlineWatches` | Enable  |                                                                                    |
+| `-XX:-JITInlineWatches` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
+
+When enabled, this option turns on experimental performance improvements relating to JVMTI watched fields.
+
+
+<!-- ==== END OF TOPIC ==== xxjitinlinewatches.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -287,6 +287,7 @@ pages:
             - "-XX:InitialRAMPercentage"                                         : xxinitialrampercentage.md
             - "-XX:InitialHeapSize"                                              : xxinitialheapsize.md
             - "-XX:[+|-]InterleaveMemory"                                        : xxinterleavememory.md
+            - "-XX:[+|-]JITInlineWatches"                                        : xxjitinlinewatches.md            
             - "-XX:[+|-]LazySymbolResolution"                                    : xxlazysymbolresolution.md
             - "-XX:MaxDirectMemorySize"                                          : xxmaxdirectmemorysize.md
             - "-XX:MaxHeapSize"                                                  : xxinitialheapsize.md              #redirect    


### PR DESCRIPTION
New option for turning on experimental JIT performance improvements
to support JVMTI watched fields.

- new topic
- update to release topic
- entry in Table of Contents

Closes: #252

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>