### PR TITLE
Remove Java 12 icon from jps topic

### DIFF
--- a/docs/tool_jps.md
+++ b/docs/tool_jps.md
@@ -22,9 +22,7 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# Java process status (`jps`)
-
-![Start of content that applies only to Java 12](cr/java12.png)
+# Java process status (`jps`) tool
 
 Use the `jps` tool to query running Java&trade; processes. The tool shows information for every Java process that is owned by the current user ID on the current host. The command syntax is as follows:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -315,7 +315,7 @@ pages:
         - "Dump viewer"                                                           : tool_jdmpview.md
         - "Trace formatter"                                                       : tool_traceformat.md
         - "Option builder"                                                        : tool_builder.md
-        - "Java process status (jps)"                                             : tool_jps.md
+        - "Java process status (jps) tool"                                        : tool_jps.md
         - "Java stack (jstack) tool"                                              : tool_jstack.md
         - "Switching to OpenJ9"                                                   : tool_migration.md        
 


### PR DESCRIPTION
In 0.13.0, jps was only supported for OpenJDK12. It
is now supported for 8 & 11, but the icon is still
indicating that it applies to 12 only. Removed.

Also modified title slightly for consistency with jstack.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>