### PR TITLE
Add changes for OpenJ9 0.14.2 release

### DIFF
--- a/docs/djdknativecbc.md
+++ b/docs/djdknativecbc.md
@@ -41,6 +41,8 @@ This option enables or disables OpenSSL native cryptographic support for the CBC
 
 OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the CBC algorithm, set this option to `false`.
 
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
 

--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -40,12 +40,13 @@ This option controls the use of OpenSSL native cryptographic support.
 
 OpenSSL support is enabled by default for the Digest, CBC, GCM, and RSA algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
 
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+
 If you want to turn off the algorithms individually, use the following system properties:
 
 - [`-Djdk.nativeCBC`](djdknativecbc.md)
 - [`-Djdk.nativeGCM`](djdknativegcm.md)
 - [`-Djdk.nativeRSA`](djdknativersa.md)
 - [`-Djdk.nativeDigest`](djdknativedigest.md)
-
 
 <!-- ==== END OF TOPIC ==== djdknativecrypto.md ==== -->

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -26,13 +26,15 @@
 
 This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
 
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+
 ## Syntax
 
         -Djdk.nativeDigest=[true|false]
 
 | Setting              | value    | Default                                                                        |
 |----------------------|----------|:------------------------------------------------------------------------------:|
-| `-Djdk.nativeDigest` | true     | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-Djdk.nativeDigest` | true     | ![Start of content that applies to Java 12 (LTS)](cr/java12.png)<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
 | `-Djdk.nativeDigest` | false    |                                                                                |
 
 ## Explanation

--- a/docs/djdknativegcm.md
+++ b/docs/djdknativegcm.md
@@ -40,6 +40,8 @@ This option enables or disables OpenSSL native cryptographic support for the GCM
 
 OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the GCM algorithm, set this option to `false`.
 
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
 

--- a/docs/djdknativersa.md
+++ b/docs/djdknativersa.md
@@ -41,6 +41,8 @@ This option enables or disables OpenSSL native cryptographic support for the RSA
 
 OpenSSL support is enabled by default for the CBC, Digest, GCM, and RSA algorithm. If you want to turn off the RSA algorithm, set this option to `false`.
 
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+
 To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -69,17 +69,18 @@ To improve the performance of applications that run in containers, try setting t
 
 OpenJDK uses the in-built Java cryptographic implementation by default. However, native cryptographic implementations
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
-Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.1.x implementation is
-currently supported for the Digest, CBC, GCM, and RSA algorithms.
+Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.0.x and V1.1.x implementations are currently supported for the Digest, CBC, GCM, and RSA algorithms.
 
-The OpenSSL V1.0.2 implementation is also supported for the Digest, CBC, GCM, and RSA algorithms. On Linux and AIX platforms, the OpenSSL 1.0.2 or 1.1.X library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.X library is currently bundled with the binaries from AdoptOpenJDK.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+
+On Linux and AIX platforms, the OpenSSL 1.0.x or 1.1.x library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.x library is currently bundled with the binaries from AdoptOpenJDK.
 
 OpenSSL support is enabled by default for all supported algorithms. If you want to limit support to specific algorithms, a number of
 system properties are available for tuning the implementation.
 
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
-- To turn off **Digest**, set `-Djdk.nativeDigest=false`
+- ![Start of content that applies only to Java 12](cr/java12.png) To turn off **Digest**, set `-Djdk.nativeDigest=false`
 - To turn off **CBC**, set `-Djdk.nativeCBC=false`
 - To turn off **GCM**, set `-Djdk.nativeGCM=false`
 - To turn off **RSA**, set `-Djdk.nativeRSA=false`
@@ -96,7 +97,7 @@ To build a version of OpenJDK with OpenJ9 that includes OpenSSL support, follow 
 - [OpenJDK 11 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md).
 - [OpenJDK 12 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V12.md).
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you obtain an OpenJDK with OpenJ9 build from [AdoptOpenJDK](https://adoptopenjdk.net/) that includes OpenSSL v1.1.x or build a version yourself that includes OpenSSL v1.1.x support, the following acknowledgements apply in accordance with the license terms:
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you obtain an OpenJDK with OpenJ9 build from [AdoptOpenJDK](https://adoptopenjdk.net/) that includes OpenSSL or build a version yourself that includes OpenSSL support, the following acknowledgements apply in accordance with the license terms:
 
 - *This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. (http://www.openssl.org/).*
 - *This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).*

--- a/docs/version0.14.2.md
+++ b/docs/version0.14.2.md
@@ -1,0 +1,59 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# What's new in version 0.14.2
+
+The following new features and notable changes since v.0.14.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Support for OpenSSL 1.0.2](#support-for-openssl-102)
+- [OpenSSL Digest algorithm disabled](#openssl-digest-algorithm-disabled)
+
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.14.2 supports OpenJDK 8 and 11. Binaries are available from the AdoptOpenJDK community at the following links:
+
+- [OpenJDK version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
+
+The Windows (MSI) installer for these binaries can now be used to optionally install the IcedTea-Web package, which provides
+equivalent functionality to Java Web Start. For more information about the installer, see the AdoptOpenJDK [Installation page](https://adoptopenjdk.net/installation.html). For more information about migrating to IcedTea-Web, read the AdoptOpenJDK
+[Migration Guide](https://adoptopenjdk.net/migration.html).
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Support for OpenSSL 1.0.1
+
+OpenSSL version 1.0.1 support is now enabled; Earlier releases supported only OpenJDK 1.0.2 and 1.1.x. On Linux&reg; and AIX&reg; platforms, the OpenSSL libraries are expected to be available on the system path. For more information about cryptographic acceleration with OpenSSL, see [Cryptographic operations](introduction.md#cryptographic-operations).
+
+### OpenSSL Digest algorithm disabled
+
+Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is disabled. 
+
+
+<!-- ==== END OF TOPIC ==== version0.14.2.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ pages:
     - "New to OpenJ9?"                                                           : openj9_newuser.md
 
     - "Release notes" :
+        - "Version 0.14.2"                                                       : version0.14.2.md
         - "Version 0.14.0"                                                       : version0.14.md
         - "Version 0.13.0"                                                       : version0.13.md
         - "Version 0.12.1"                                                       : version0.12.1.md


### PR DESCRIPTION
- Add OpenSSL 1.0.1 support
- Digest algorithm disabled by default

CLoses: #269
Closes: #260

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>