### PR TITLE
Re-enable changes for CS on z

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -106,8 +106,7 @@ A special mode of the `gencon` policy is known as *Concurrent Scavenge* (`-Xgc:c
     - [Reducing Garbage Collection pause times with Concurrent Scavenge and the Guarded Storage Facility](https://developer.ibm.com/javasdk/2017/09/18/reducing-garbage-collection-pause-times-concurrent-scavenge-guarded-storage-facility/)
     - [How Concurrent Scavenge using the Guarded Storage Facility Works](https://developer.ibm.com/javasdk/2017/09/25/concurrent-scavenge-using-guarded-storage-facility-works/)
 
-<!-- 0.15 change to be re-enabled - **Software-based support: (64-bit: Linux on (x86-64, POWER, IBM Z&reg;), AIX&reg;, and z/OS&reg;)** -->
-- **Software-based support: (Linux on x86-64, Linux on POWER LE, AIX&reg; on POWER&reg;)** With software-based support, *Concurrent Scavenge* can be enabled without any pre-requisite hardware although the performance throughput is not as good as hardware-based support.
+- **Software-based support: (64-bit: Linux on (x86-64, POWER, IBM Z&reg;), AIX&reg;, and z/OS&reg;)** With software-based support, *Concurrent Scavenge* can be enabled without any pre-requisite hardware although the performance throughput is not as good as hardware-based support.
 
 For more information about enabling Concurrent Scavenge, see the [-Xgc:concurrentScavenge](xgc.md#concurrentscavenge) option.
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -61,11 +61,9 @@ Options that change the behavior of the Garbage Collector (GC).
 
     <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note: Linux on Z and z/OS**
 
-<!-- 0.15.0 change to be re-enabled : This option is supported by all generations of IBM Z&reg; hardware to enable pause-less GC with two modes of operation: hardware-based and software-based operations. IBM z13&trade; and earlier hardware operates in software-based pause-less GC mode; and IBM z14&trade; and later hardware (with supported software) operates in hardware-based mode. 
+    This option is supported by all generations of IBM Z&reg; hardware to enable pause-less GC with two modes of operation: hardware-based and software-based operations. IBM z13&trade; and earlier hardware operates in software-based pause-less GC mode; and IBM z14&trade; and later hardware (with supported software) operates in hardware-based mode. 
 
-    Hardware-based pause-less GC is supported on IBM z14&trade; and later hardware running the following software: -->
-
-    This option is supported on IBM z14&trade; hardware running the following software:
+    Hardware-based pause-less GC is supported on IBM z14&trade; and later hardware running the following software:
 
     Operating systems:
 


### PR DESCRIPTION
Changes backed out due to 0.14.2 release, now
re-enabled to show support for concurrentScavenge mode
on IBM Z systems.

Original PR: https://github.com/eclipse/openj9-docs/pull/262

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>