### PR TITLE
Add jextract information back into docs/tool_jdmpview.md

### DIFF
--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -36,10 +36,16 @@ The dump viewer is useful for diagnosing `OutOfMemoryError` exceptions in Java&t
 
 ### Starting the dump viewer
 
-    jdmpview -core <core file>
+`jdmpview (-core <core file> | -zip <zip file>) [-notemp]`
 
 
-Where `<core file>` specifies a dump file.                                                                                 
+|          Input option   |  Explanation                                                                                           |
+|-------------------------|--------------------------------------------------------------------------------------------------------|
+| `-core <core file>`     | Specifies a dump file.                                                                                 |
+| `-zip <zip file>`       | Specifies a compressed file containing the core file and associated XML file (produced by the [dump extractor (`jextract`)](tool_jextract.md) tool on AIX&reg; and Linux&trade; systems). |
+| `-notemp`               | By default, when you specify a file by using the `-zip` option, the contents are extracted to a temporary directory before processing. Use the `-notemp` option to prevent this extraction step, and run all subsequent commands in memory. |
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The `-core` option can be used with the `-zip` option to specify the core and XML files in the compressed file. Without these options, `jdmpview` shows multiple contexts, one for each source file that it identified in the compressed file.  
 
 On z/OS&reg;, you can copy the dump to an HFS file and supply that as input to `jdmpview`, or you can supply a fully qualified MVS&trade; data set name. For example:
 
@@ -623,7 +629,7 @@ User input is prefaced by a greater than symbol (>).
     info system                                    displays information about the system the core dump is from
     info thread                                    displays information about Java and native threads
     log                       [name level]         display and control instances of java.util.logging.Logger
-    open                      [path to core]       opens the specified core file
+    open                      [path to core or zip] opens the specified core or zip file
     plugins                                        Plugin management commands
                          list                      Show the list of loaded plugins for the current context
                        reload                      Reload plugins for the current context

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -26,7 +26,7 @@
 
 **(AIX&reg;, Linux&trade;, ![Start of content that applies only to Java 11 (LTS) and later](cr/java11plus.png) macOS&reg;![End of content that applies only to Java 10 and later](cr/java_close_lts.png))**
 
-On some operating systems, copies of executable files and libraries are required for a full analysis of a core dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these extra files and package them into an archive file along with the core dump.
+On some operating systems, copies of executable files and libraries are required for a full analysis of a core dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these extra files and package them into an archive file along with the core dump. To analyze the output, use the [dump viewer (`jdmpview`)](tool_jdmpview.md).
 
 ## Syntax
 
@@ -35,13 +35,11 @@ On some operating systems, copies of executable files and libraries are required
 where:
 
 - `<core file name>` is the name of the system dump.
-- `<zip_file>` is the name you want to give to the processed file. If you do not specify a name, output is written to `<core file name>.zip` by default.
+- `<zip_file>` is the name you want to give to the processed file. If you do not specify a name, output is written to `<core file name>.zip` by default. The output is written to the same directory as the core file.
 
 If you are analyzing a dump from a VM that used [`-Xcompressedrefs`](xcompressedrefs.md), include the `-J-Xcompressedrefs` parameter to run `jextract` using compressed references.
 
-: <i class="fa fa-exclamation-triangle"></i> **Restriction: ** You must run `jextract` using the same VM level, on the same system that produced the system dump. The `jextract` utility compresses the dump, executable files, and libraries into a single .zip file for use in subsequent problem diagnosis. To analyze the output, use the [dump viewer (`jdmpview`)](tool_jdmpview.md).
-
-    If you run `jextract` on a VM level that is different from the one on which the dump was produced you see the following messages:
+: <i class="fa fa-exclamation-triangle"></i> **Restriction: ** You must run `jextract` using the same VM level, on the same system that produced the system dump. If you run `jextract` on a VM level that is different from the one on which the dump was produced you see the following messages:
 
         J9RAS.buildID is incorrect (found e8801ed67d21c6be, expecting eb4173107d21c673).
         This version of jextract is incompatible with this dump.

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -24,9 +24,9 @@
 
 # Dump extractor (`jextract`)
 
-**(AIX&reg; & Linux&trade; only)**
+**(AIX&reg;, Linux&trade;, ![Start of content that applies only to Java 11 (LTS) and later](cr/java11plus.png) macOS&reg;![End of content that applies only to Java 10 and later](cr/java_close_lts.png))**
 
-For a full analysis of core dumps from Linux and AIX platforms, copies of executable files and libraries are required along with the system dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these files.
+On some operating systems, copies of executable files and libraries are required for a full analysis of a core dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these extra files and package them into an archive file along with the core dump.
 
 ## Syntax
 

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -1,0 +1,57 @@
+<!--
+* Copyright (c) 2017, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# Dump extractor (`jextract`)
+
+**(AIX&reg; & Linux&trade; only)**
+
+For an analysis of core dumps from Linux and AIX platforms, copies of executable files and libraries are required along with the system dump. Run the `jextract` utility to collect these files.
+
+## Syntax
+
+        jextract <core file name> [<zip_file>]
+
+where:
+
+- `<core file name>` is the name of the system dump.
+- `<zip_file>` is the name you want to give to the processed file. If you do not specify a name, output is written to `<core file name>.zip` by default.
+
+If you are analyzing a dump from a VM that used [`-Xcompressedrefs`](xcompressedrefs.md), include the `-J-Xcompressedrefs` parameter to run `jextract` using compressed references.
+
+: <i class="fa fa-exclamation-triangle"></i> **Restriction: ** You must run `jextract` using the same VM level, on the same system that produced the system dump. The `jextract` utility compresses the dump, executable files, and libraries into a single .zip file for use in subsequent problem diagnosis. To analyze the output, use the [dump viewer (`jdmpview`)](tool_jdmpview.md).
+
+    If you run `jextract` on a VM level that is different from the one on which the dump was produced you see the following messages:
+
+        J9RAS.buildID is incorrect (found e8801ed67d21c6be, expecting eb4173107d21c673).
+        This version of jextract is incompatible with this dump.
+        Failure detected during jextract, see previous message(s).
+
+## See also
+
+- [Dump viewer (`jdmpview`)](tool_jdmpview.md)
+
+
+
+
+<!-- ==== END OF TOPIC ==== tool_jextract.md ==== -->

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -26,7 +26,7 @@
 
 **(AIX&reg; & Linux&trade; only)**
 
-For an analysis of core dumps from Linux and AIX platforms, copies of executable files and libraries are required along with the system dump. Run the `jextract` utility to collect these files.
+For a full analysis of core dumps from Linux and AIX platforms, copies of executable files and libraries are required along with the system dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these files.
 
 ## Syntax
 

--- a/docs/xrs.md
+++ b/docs/xrs.md
@@ -24,7 +24,7 @@
 
 # -Xrs
 
-Prevents the OpenJ9 run time environment from handling any internally or externally generated signals such as `SIGSEGV` and `SIGABRT`. Any signals that are raised are handled by the default operating system handlers.
+Prevents the OpenJ9 runtime environment from handling any internally or externally generated signals such as `SIGSEGV` and `SIGABRT`. Any signals that are raised are handled by the default operating system handlers, which you might want if you are using a debugger such as GDB or WinDbg to diagnose problems in JNI code.
 
 Disabling signal handling in the OpenJ9 VM reduces performance by approximately 2-4%, depending on the application.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -316,6 +316,7 @@ pages:
 
 
     - "Tools" :
+        - "Dump extractor"                                                        : tool_jextract.md    
         - "Dump viewer"                                                           : tool_jdmpview.md
         - "Trace formatter"                                                       : tool_traceformat.md
         - "Option builder"                                                        : tool_builder.md


### PR DESCRIPTION
See https://github.com/eclipse/openj9-docs/issues/268

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>

[skip ci]