### PR TITLE
Deprecate XX:IdleTuningCompactOnIdle

### DIFF
--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -74,6 +74,9 @@ This option was redundant and has now been removed. If you try to use this optio
 
 `JVMJ9VM007E Command-line option unrecognised: -Xdiagnosticscollector`
 
+### Heuristics for compaction during idle GC
+OpenJ9 now automatically compacts the heap when certain triggers are met during idle GC. As a result of this change, [`-XX:[+|-]IdleTuningCompactOnIdle`](xxidletuningcompactonidle.md) has been deprecated.
+
 <!--## Full release information
 
 To see a complete list of changes between Eclipse OpenJ9 V0.14.0 and V0.15.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.15/0.15.md).-->

--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -34,6 +34,8 @@
 - [Support for OpenJDK HotSpot options](#support-for-openjdk-hotspot-options)
 - [Support for Transparent HugePage](#support-for-transparent-hugepage)
 - [Removal of -Xdiagnosticscollector option](#removal-of-xdiagnosticscollector-option)
+- [Change in behaviour of -XX:\[+|-\]IdleTuningCompactOnIdle](#change-in-behaviour-of-xx:idletuningcompactonidle)
+- [Addition of heuristics for compaction during idle GC](#heuristics-for-compaction-during-idle-gc)
 
 
 ## Features and changes
@@ -73,6 +75,9 @@ The VM now supports the allocation of huge pages on Linux when you use the `madv
 This option was redundant and has now been removed. If you try to use this option on the command line, the VM outputs this error message:
 
 `JVMJ9VM007E Command-line option unrecognised: -Xdiagnosticscollector`
+
+### Change in behaviour of -XX:IdleTuningCompactOnIdle
+-XX:[+|-]IdleTuningCompactOnIdle is now no longer effective when -XX:+IdleTuningGcOnIdle is not specified.
 
 ### Heuristics for compaction during idle GC
 OpenJ9 now automatically compacts the heap when certain triggers are met during idle GC. As a result of this change, [`-XX:[+|-]IdleTuningCompactOnIdle`](xxidletuningcompactonidle.md) has been deprecated.

--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -28,7 +28,11 @@
 
 This option controls garbage collection processing with compaction when the state of the OpenJ9 VM is set to idle.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** 
+1. This option is deprecated and will be removed in the future. 
+2. This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use.
+3. This option is not effective if the object heap is configured to use large pages.
+4. This option is not effective if [XX:+IdleTuningGcOnIdle](xxidletuninggconidle.md) is not specified.
 
 ## Syntax
 

--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -28,10 +28,10 @@
 
 This option controls garbage collection processing with compaction when the state of the OpenJ9 VM is set to idle.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** 
-1. This option is deprecated and will be removed in the future. 
-2. This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use.
-3. This option is not effective if the object heap is configured to use large pages.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**  
+1. This option was deprecated in release 0.15.0 and will be removed in the future. 
+2. This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. 
+3. This option is not effective if the object heap is configured to use large pages. 
 4. This option is not effective if [XX:+IdleTuningGcOnIdle](xxidletuninggconidle.md) is not specified.
 
 ## Syntax
@@ -45,7 +45,7 @@ This option controls garbage collection processing with compaction when the stat
 
 The default depends on whether or not the OpenJ9 VM is running in a container. As indicated in the table, when the VM is running in a container and the state is set to idle, the VM attempts to compact the object heap following a garbage collection cycle. The garbage collection cycle is controlled by the `-XX:+IdleTuningGcOnIdle` option, which is also enabled by default when the OpenJ9 VM is running inside a container.
 
-If your application is not running in a container and you want to enable compaction as part of the idle-tuning process, set the `-XX:+IdleTuningCompactOnIdle` option on the command line when you start your application.
+If your application is not running in a container and you want compaction to be attempted every time idle GC happens as part of the idle-tuning process, set the `-XX:+IdleTuningCompactOnIdle` option on the command line when you start your application.
 
 The `-XX:+IdleTuningCompactOnIdle` option can be used with the `-XX:+IdleTuningMinIdleWaitTime`, which controls the amount of time that the VM must be idle before an idle state is set. If a value for the `-XX:+IdleTuningMinIdleWaitTime` option is not explicitly specified, the VM sets a default value of 180 seconds.
 

--- a/docs/xxidletuninggconidle.md
+++ b/docs/xxidletuninggconidle.md
@@ -26,7 +26,7 @@
 
 **(Linux&reg; only)**
 
-This option controls whether a garbage collection cycle takes place when the state of the OpenJ9 VM is set to idle.
+This option controls whether a garbage collection cycle takes place when the state of the OpenJ9 VM is set to idle. Compaction of the heap is also attempted during the idle GC when certain triggers are met.
 
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:** This option applies only to Linux&reg; architectures when the Generational Concurrent (`gencon`) garbage collection policy is in use. This option is not effective if the object heap is configured to use large pages.
 
@@ -39,7 +39,7 @@ This option controls whether a garbage collection cycle takes place when the sta
 | `-XX:+IdleTuningGcOnIdle` | Enable  |  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
 | `-XX:-IdleTuningGcOnIdle` | Disable |  <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>   |   |
 
-The default depends on whether or not the OpenJ9 VM is running in a docker container. As indicated in the table, when the VM is running in a container and the state is set to idle, this option causes the VM to release free memory pages in the object heap without resizing the Java&trade; heap. The pages are reclaimed by the operating system, which reduces the physical memory footprint of the VM. In a container environment, the VM also attempts to compact the object heap before releasing memory by default, which is controlled by the `-XX:[+|-]IdleTuningCompactOnIdle` option.
+The default depends on whether or not the OpenJ9 VM is running in a docker container. As indicated in the table, when the VM is running in a container and the state is set to idle, this option causes the VM to release free memory pages in the object heap without resizing the Java&trade; heap and attempts to compact the heap after the garbage collection cycle if certain heuristics are triggered. The pages are reclaimed by the operating system, which reduces the physical memory footprint of the VM.
 
 If your application is not running in a container and you want to enable idle-tuning, set the `-XX:+IdleTuningGcOnIdle` option on the command line when you start your application.
 
@@ -52,7 +52,6 @@ When enabled, the `-XX:+IdleTuningGcOnIdle` option is used with the `-XX:IdleTun
 
 - [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md)
 - [-XX:IdleTuningMinFreeHeapOnIdle](xxidletuningminfreeheaponidle.md)
-- [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md)
-
+- [-XX:\[+|-\]IdleTuningCompactOnIdle \(deprecated\)](xxidletuningcompactonidle.md)
 
 <!-- ==== END OF TOPIC ==== xxidletuninggconidle.md ==== -->

--- a/docs/xxidletuningminfreeheaponidle.md
+++ b/docs/xxidletuningminfreeheaponidle.md
@@ -48,8 +48,8 @@ If you set `-XX:IdleTuningMinFreeHeapOnIdle=10`, no more than 90% of the free me
 ## See also
 
 - [-XX:IdleTuningMinIdleWaitTime](xxidletuningminidlewaittime.md)
-- [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md)
 - [-XX:\[+|-\]IdleTuningGcOnIdle](xxidletuninggconidle.md)
+- [-XX:\[+|-\]IdleTuningCompactOnIdle \(deprecated\)](xxidletuningcompactonidle.md)
 
 
 <!-- ==== END OF TOPIC ==== xxidletuningminfreeheaponidle.md ==== -->

--- a/docs/xxidletuningminidlewaittime.md
+++ b/docs/xxidletuningminidlewaittime.md
@@ -49,10 +49,8 @@ Setting the value to 0 disables this feature, which causes the following idle tu
 
 ## See also
 
--   [-XX:\[+|-\]IdleTuningCompactOnIdle](xxidletuningcompactonidle.md)
 -   [-XX:\[+|-\]IdleTuningGcOnIdle](xxidletuninggconidle.md)
 -   [-XX:IdleTuningMinFreeHeapOnIdle](xxidletuningminfreeheaponidle.md#xxidletuningminfreeheaponidle)
-
-
+-   [-XX:\[+|-\]IdleTuningCompactOnIdle \(deprecated\)](xxidletuningcompactonidle.md)
 
 <!-- ==== END OF TOPIC ==== xxidletuningminidlewaittime.md ==== -->


### PR DESCRIPTION
Added dependency to XX:IdleTuningCompactOnIdle and
deprecated XX:IdleTuningCompactOnIdle. Also documented
added heuristics in version changelogs.

Fixes #277 

Signed-off-by: Shishir Halaharvi <shishir.neo95@gmail.com>