### PR TITLE
Digest algorithm disabled in Java 12

### DIFF
--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -42,7 +42,7 @@ OpenSSL support is enabled by default for the Digest, CBC, GCM, RSA, and ChaCha2
 
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
 
--  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+-  ![Start of content that applies to Java 8 (LTS) and later](cr/java8plus.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8 and later)](cr/java_close_lts.png)
 -  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
 
 If you want to turn off the algorithms individually, use the following system properties:

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -26,7 +26,8 @@
 
 This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS) and later](cr/java8plus.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled.
+This option cannot be used to turn on Digest support. ![End of content that applies to Java 8 and later](cr/java_close_lts.png)
 
 ## Syntax
 
@@ -34,12 +35,14 @@ This option enables or disables OpenSSL native cryptographic support for the Dig
 
 | Setting              | value    | Default                                                                        |
 |----------------------|----------|:------------------------------------------------------------------------------:|
-| `-Djdk.nativeDigest` | true     | ![Start of content that applies to Java 12 (LTS)](cr/java12.png)<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
-| `-Djdk.nativeDigest` | false    |                                                                                |
+| `-Djdk.nativeDigest` | true     |                                                                                |
+| `-Djdk.nativeDigest` | false    | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
 
 ## Explanation
 
-OpenSSL support is enabled by default for the Digest algorithm. If you want to turn off this algorithm only, set this option to `false`. To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
+<!--OpenSSL support is enabled by default for the Digest algorithm. If you want to turn off this algorithm only, set this option to `false`.-->
+
+ To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
 
 
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -71,7 +71,7 @@ OpenJDK uses the in-built Java cryptographic implementation by default. However,
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
 Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.0.x and V1.1.x implementations are currently supported for the Digest, CBC, GCM, and RSA algorithms. The OpenSSL V1.1.x implementation is also supported for the ChaCha20 and ChaCha20-Poly1305 algorithms.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies only to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 and later](cr/java8plus.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8 and later)](cr/java_close_lts.png)
 
 On Linux and AIX platforms, the OpenSSL 1.0.x or 1.1.x library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.x library is currently bundled with the binaries from AdoptOpenJDK.
 
@@ -80,7 +80,7 @@ system properties are available for tuning the implementation.
 
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
-- ![Start of content that applies only to Java 12](cr/java12.png) To turn off **Digest**, set `-Djdk.nativeDigest=false`![End of content that applies only to Java 12 (LTS)](cr/java_close.png)
+- To turn off **Digest**, set `-Djdk.nativeDigest=false` (See **Restriction**. This system property cannot be used to enable the Digest algorithm)
 - To turn off **ChaCha20** and **ChaCha20-Poly1305**, set `-Djdk.nativeChaCha20=false`. <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) These algorithms are not supported on Java 8 or 12![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
 - To turn off **CBC**, set `-Djdk.nativeCBC=false`
 - To turn off **GCM**, set `-Djdk.nativeGCM=false`

--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -31,6 +31,7 @@
 - [Performance improvements for JVMTI watched fields](#performance-improvements-for-jvmti-watched-fields)
 - [Support for pause-less garbage collection on IBM Z systems](#support-for-pause-less-garbage-collection-on-ibm-z-systems)
 - ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) [ChaCha20 algorithm support for OpenSSL](#chacha20-algorithm-support-for-openssl)![End of content that applies only to Java 11 (LTS)](cr/java_close_lts.png)
+- ![Start of content that applies only to Java 12)](cr/java12.png) [OpenSSL Digest algorithm disabled](#openssl-digest-algorithm-disabled)![End of content that applies only to Java 12](cr/java_close.png)
 - [Support for OpenJDK HotSpot options](#support-for-openjdk-hotspot-options)
 - [Support for Transparent HugePage](#support-for-transparent-hugepage)
 - [New Java memory map (jmap) tool](#new-java-memory-map-tool)
@@ -61,6 +62,11 @@ Support for Concurrent scavenge mode is now extended to Linux on IBM Z&reg; syst
 ### ![Start of content that applies only to Java 11 (LTS)](cr/java11.png) ChaCha20 algorithm support for OpenSSL
 
 The ChaCha20 and ChaCha20-Poly1305 algorithms can now use OpenSSL on Java 11. For more information, see [`-Djdk.nativeChaCha20`](djdknativechacha20.md). ![End of content that applies only to Java 11 (LTS)](cr/java_close_lts.png)
+
+### ![Start of content that applies only to Java 12)](cr/java12.png) OpenSSL Digest algorithm disabled
+
+Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is disabled. This algorithm was disabled
+for Java 8 and 11 in release 0.14.2, which did not support Java 12.
 
 ### Support for OpenJDK HotSpot options
 


### PR DESCRIPTION
Digest was disabled in 0.14.2, which applied only
to Java 8 & 11. Digest algorithm is now turned off
in Java 12 for the same reason.

Closes: #294

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>