### PR TITLE
Include tip for using jlink

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -112,6 +112,11 @@ Runtime options are specified on the command line and include system properties,
 
 If you do not specify any options on the command line at run time, the OpenJ9 VM starts with default settings that define how it operates. For more information about these settings, see [Default settings for the OpenJ9 VM](openj9_defaults.md).
 
+## ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) Using Jlink
+
+On Java 11 and later, you can use the `jlink` utility to create a custom OpenJ9 runtime image, which allows you to optimize image size.
+If you do not require translations from the English language, the translation files can be removed to further optimize the size. You can achieve this by specifying the `--exclude-files=**java_**.properties` option when you run `jlink`. The default English `java.properties` file is unaffected.
+
 ## Troubleshooting
 
 The OpenJ9 diagnostic component contains extensive features to assist with problem determination. Diagnostic data is produced under default conditions, but can also be controlled by starting the VM with the [-Xdump option](xdump.md) or using the `com.ibm.jvm.Dump` API. You can also trace Java applications, methods, and VM operations by using the [-Xtrace option](xtrace.md).


### PR DESCRIPTION
If translations from English are not required,
tell users how to exclude the translated property
files, which reduces the size of the image.

Closes: #308

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>