### PR TITLE
Updated Diag overview to support new structure

### DIFF
--- a/docs/diag_overview.md
+++ b/docs/diag_overview.md
@@ -24,9 +24,11 @@
 
 # Diagnostic data and tooling
 
-OpenJ9 contains extensive trace and debugging capabilities to help identify, isolate, and solve run time problems. Various types of dumps are produced by default in response to certain events, such as a GPF fault or an `OutOfMemoryError` exception. You can also trigger the production of dumps by using the `com.ibm.jvm.Dump` API or by specifying `-Xdump` options on the command line.
+OpenJ9 contains a broad range of diagnostic capabilities to help identify, isolate, and solve run time problems. These capabilities include dump files, verbose logs, and trace files, which are supported by a variety of diagnostic tools and interfaces.  
 
 ## Dumps
+
+Various types of dumps are produced by default in response to certain events, such as a GPF fault or an `OutOfMemoryError` exception. You can also trigger the production of dumps by using the `com.ibm.jvm.Dump` API or by specifying `-Xdump` options on the command line.
 
 All dumps are produced by dump agents, which are initialized when the OpenJ9 VM starts. Different dumps target different areas of the runtime environment. If you want to generate a dump to diagnose a particular type of problem, you need to understand what data the dump will provide. The following dumps are typically used for problem diagnosis:   
 
@@ -48,29 +50,70 @@ Some components of OpenJ9 can also produce verbose output or log files to assist
 
 - Class loader operations can be analyzed by producing verbose output from the `-verbose:dynload` standard option, which shows detailed information as each class is loaded by the VM.
 
-## Debugging tools
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you are already familiar with tools that are provided with HotSpot, see [Switching to OpenJ9](tool_migration.md), which explains some of the differences you might encounter when using OpenJ9 .
-
-### Trace facility
+## Trace files
 
 The OpenJ9 trace facility can be used to trace applications, Java methods, or internal JVM operations with minimal impact on performance. Trace is configured by using the [-Xtrace](xtrace.md) command line option, which allows you to control what is traced and when.
 
-Trace data is produced in binary format and must be processed by the OpenJ9 trace formatter to convert it to a readable form. For more information, see [Trace formattter](tool_traceformat.md).
+Trace data is produced in binary format and must be processed by the OpenJ9 trace formatter to convert it to a readable form. For more information, see [Trace formatter](tool_traceformat.md).
+
+## Diagnostic tools
+
+A number of diagnostic tools are available with OpenJ9 to assist with the analysis of dump and trace files.
+
+### Dump extractor
+
+The dump extractor (`jextract`) supports a full analysis of core files on specific platforms by collecting key files from a system and packaging them into an archive along with a core dump. This archive file is extremely useful when reporting issues to the OpenJ9
+community, helping to ensure a faster analysis and turnaround. For more information, see
+[Dump extractor](tool_jextract.md).
 
 ### Dump viewer
 
 Because system dumps are binary files, OpenJ9 provides a dump viewer tool (`jdmpview`) to analyze the contents. This tool can work with dumps from any platforms independently of a system debugger. For more information, see [Dump viewer](tool_jdmpview.md).
 
+### Trace formatter
+
+The trace formatter tool converts binary trace point data in a trace file into a readable format for analysis. For more information, see
+[Trace formatter](tool_traceformat.md).
+
+### Option builder
+
+OpenJ9 contains an extensive set of command-line options to assist with problem diagnosis. Certain options are complex, containing
+many sub-options with numerous parameters. Whilst these offer a great degree of flexibility, the syntax can be difficult to construct.
+Option builder tools are available that provide a simple graphical user interface to help you construct your command-line argument.
+For more information, see [Option builder](tool_builder.md).
+
+### HotSpot-compatible tools
+
+A number of tools are available for compatibility with the reference implementation. These tools are independently implemented by
+OpenJ9 but have similar functions, allowing users to migrate more easily. The available tools are listed in the Tools section.  
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you are already familiar with tools that are provided with HotSpot, see [Switching to OpenJ9](tool_migration.md), which explains some of the differences you might encounter when using OpenJ9.
+
+### Eclipse marketplace tools
+
+OpenJ9 provides support for a number of monitoring and diagnostic tools that can be found in the [Eclipse marketplace](https://marketplace.eclipse.org/). Each tool provides a graphical user interface to help you visualize data and, in some cases, can provide tuning or debugging recommendations.
+
+- [**Health Center:**](https://marketplace.eclipse.org/content/ibm-monitoring-and-diagnostic-tools-health-center) Provides real-time monitoring of running applications with minimal overhead over the network. You can monitor a whole range of operations including, class loading, CPU usage, GC heap and pause times, I/O activity, lock contention, method trace, native memory usage, profiling, and live threads. For more information, read the [Health Center documentation](https://www.ibm.com/support/knowledgecenter/en/SS3KLZ/com.ibm.java.diagnostics.healthcenter.doc/homepage/plugin-homepage-hc.html).
+- [**Garbage Collection Memory Vizualizer (GCMV):**](https://marketplace.eclipse.org/content/ibm-monitoring-and-diagnostic-tools-garbage-collection-and-memory-visualizer-gcmv) Plots GC and native memory data over time. You can view and save data as a report, raw log, tabulated data, or in graphical format. The tool helps to diagnose problems such as memory leaks with data presented in various visual formats for analysis. Tuning recommendations are also provided. For more information, read the [GCMV documentation](https://www.ibm.com/support/knowledgecenter/en/SS3KLZ/com.ibm.java.diagnostics.visualizer.doc/homepage/plugin-homepage-gcmv.html).
+- [**Memory Analyzer:**](https://marketplace.eclipse.org/content/memory-analyzer-0) Examines the Java object heap to help find memory leaks or reduce memory consumption. Support is available for OpenJ9 via the DTFJ interface (Install from the Eclipse Help menu; Install New Software > Work with "IBM Diagnostic Tool Framework for Java" > IBM Monitoring and Diagnostic Tools > Diagnostic Tool Framework for Java). More information about Eclipse MAT can be found on the [project website page](https://www.eclipse.org/mat/).
+- [**Interactive Diagnostic Data Explorer (IDDE):**](https://marketplace.eclipse.org/content/ibm-monitoring-and-diagnostic-tools-interactive-diagnostic-data-explorer-idde) A GUI alternative to the OpenJ9 [dump viewer](tool_jdmpview.md), which can examine the contents of an OpenJ9 system dump. For more information, read the [IDDE documentation](https://www.ibm.com/support/knowledgecenter/en/SS3KLZ/com.ibm.java.diagnostics.idde.doc/homepage/plugin-homepage-idde.html).
+
+If you are familiar with using HotSpot as part of an Oracle JDK or OpenJDK, the Java VisualVM utility is functionally similar to Health Center.
+
 ## Interfaces
 
-### JVMTI tools interface
+### JVM tool interface (JVMTI)
 
 OpenJ9 supports the Java Virtual Machine Tool Interface (JVMTI) and provides extensions that allow JVMTI tools to obtain diagnostic information or trigger diagnostic operations in the VM. For more information, see [Java Virtual Machine Tool Interface](interface_jvmti.md).
 
 ### DTFJ Interface
 
-OpenJ9 includes the Diagnostic Tool Framework for Java (DTFJ) API. Custom applications can be written that use this API to access a wide range of information in a system dump or a Java dump. For more information, see [Diagnostic Tool Framework for Java](interface_dtfj.md).
+OpenJ9 includes the Diagnostic Tool Framework for Java (DTFJ) API. Custom applications can be written that use this API to access a wide range of information in a system dump or a Java dump. DTFJ can be used with the Eclipse Memory Analyzer Toolkit (MAT) to examine the Java object heap for memory leaks and to reduce memory consumption. For more information, see [Diagnostic Tool Framework for Java](interface_dtfj.md).
+
+### `java.lang.management` API
+
+OpenJ9 provides MXBean additions and extensions to this standard API, which enables you to use tools such as JConsole to monitor and manage your Java applications. For more information, see [MBeans and MXBeans](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mxbeans.html) in the IBM® Knowledge Center.
 
 ### JPDA tools
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,7 +122,7 @@ pages:
 
     - "Diagnostics" :
 
-        - "Tools and data"                                                       : diag_overview.md
+        - "Overview"                                                             : diag_overview.md
 
         - "Dumps" :
 #          Move dump agents, events, xdump builder from -Xdump (link to -Xdump for detail) then...


### PR DESCRIPTION
The Diagnostics section is being expanded to cover all
data, tools, and interfaces supported by OpenJ9. This
requires a re-org of the current structure and an update
to the overview topic (renamed from Tools and data).

This is part of a larger piece of work, broken down into
incremental steps.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>