### PR TITLE
Change in shared classes behavior

### DIFF
--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -39,6 +39,7 @@
 - [Removal of -Xdiagnosticscollector option](#removal-of-xdiagnosticscollector-option)
 - [Change in behaviour of -XX:\[+|-\]IdleTuningCompactOnIdle](#change-in-behaviour-of-xxidletuningcompactonidle)
 - [Addition of heuristics for compaction during idle GC](#heuristics-for-compaction-during-idle-gc)
+- [Change in shared classes behavior for checking timestamps of `jar` or `zip` files](#change-in-shared-classes-behavior-for-checking-timestamps-of-jar-or-zip-files)
 
 
 ## Features and changes
@@ -105,8 +106,14 @@ This option was redundant and has now been removed. If you try to use this optio
 ### Heuristics for compaction during idle GC
 OpenJ9 now automatically compacts the heap when certain triggers are met during idle garbage collection (GC). As a result of this change, [`-XX:[+|-]IdleTuningCompactOnIdle`](xxidletuningcompactonidle.md) is deprecated.
 
-<!--## Full release information
+### Change in shared classes behavior for checking timestamps of `jar` or `zip` files
 
-To see a complete list of changes between Eclipse OpenJ9 V0.14.0 and V0.15.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.15/0.15.md).-->
+In earlier releases, the shared classes cache checks timestamps of `jar` or `zip` files every time a class is loaded and reloads a class if the timestamp has changed. This behavior is now changed; timestamps are checked only when `zip` or `jar` files are added to class loaders and used for the first time to look for a class, which can improve class-loading performance. If `jar` or `zip` files are updated after a class loader starts loading classes from them, an older version of the class might be loaded from the shared classes cache. To revert to the behavior of earlier releases, set the [`-Xshareclasses:checkURLTimestamps`](xshareclasses.md#checkurltimestamps) option on the command line when you start your application.
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Multiple `-Xshareclasses:` options are not combined, only the last one is used.
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 V0.14.0 and V0.15.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.15/0.15.md).
 
 <!-- ==== END OF TOPIC ==== version0.15.md ==== -->

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -153,6 +153,14 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
 
 The option `enableBCI` is enabled by default. However, if you use the `cacheRetransformed` option, this option forces cache creation into `-Xshareclasses:disableBCI` mode.
 
+### `checkURLTimestamps`
+
+        -Xshareclasses:checkURLTimestamps
+
+: Causes timestamps of `jar` or `zip` files to be checked every time a class is loaded. If a timestamp has changed, the class is loaded from the `jar` or `zip` file and not from the shared cache. This sub-option is not enabled by default and reflects the legacy behavior of the shared classes cache.
+
+: <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The timestamp of a bootstrap `jar` or `zip` file is checked once when it is used for the first time to load a class.
+
 ### `destroy` (Cache utility)
 
         -Xshareclasses:destroy
@@ -344,6 +352,15 @@ case, the VM continues without using shared classes.
         -Xshareclasses:noBootclasspath
 
 :   Disables the storage of classes that are loaded by the bootstrap class loader in the shared classes cache. Often used with the `SharedClassURLFilter` API to control exactly which classes are cached. For more information about shared class filtering, see [Using the SharedClassHelper API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_helper_class.html).
+
+### `nocheckURLTimestamps`
+
+        -Xshareclasses:nocheckURLTimestamps
+
+:   Timestamps of `jar` or `zip` files are checked only when they are added to a class loader and used for the first time to look up a class. This is the default
+behavior, which can improve the performance of class loading from the shared classes cache, especially on Windows systems. To revert to the behavior of the shared classes cache in earlier releases, use the [`CheckURLTimeStamps`](xshareclasses.md#checkurltimestamps) sub-option.
+
+: <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** When the `nocheckURLTimestamps` sub-option is used (default), if `jar` or `zip` files are updated after a class loader starts loading classes from them, an older version of the class might be loaded from the shared classes cache. If this scenario occurs, use the `checkURLTimestamps` option.
 
 ### `nojitdata`
 


### PR DESCRIPTION
New -Xshareclasses suboptions to control whether timestamps
of zip or jar files are checked every time a class is loaded
or only on the first load (default).

Closes: #322

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>