### PR TITLE
Doc updates for UseGCStartupHints enabled by default

### DIFF
--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -1,0 +1,57 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# What's new in version 0.6
+
+ The following new features and notable changes since v.0.15.2 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Automatic setting of initial heap size is enabled by default](#automatic-setting-of-initial-heap-size-is-enabled-by-default)
+
+
+
+## Features and changes
+
+### Binaries and supported environments
+
+ OpenJ9 release 0.16.0 supports OpenJDK 13, which is available from the AdoptOpenJDK community at the following link:
+
+- [OpenJDK version 13](https://adoptopenjdk.net/archive.html?variant=openjdk13&jvmVariant=openj9)
+
+OpenJDK 13 with Eclipse OpenJ9 is not a long term support (LTS) release.
+
+The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK community are for Eclipse OpenJ9 release 0.15.2. Features mentioned in these release notes are not available in these builds. Although it might be possible to build an OpenJDK 8 or OpenJDK 11 with OpenJ9 0.16.0, testing at the project is not complete and therefore support for any of these features is not available.
+
+ To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Automatic setting of initial heap size is enabled by default
+
+ OpenJ9 version 0.15.1 introduced the [`-XX:[+|-]UseGCStartupHints`](xxusegcstartuphints.md) option, which, when enabled, turned on the automatic learning and setting of an appropriate heap size for an application. This option is now enabled by default.
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 V0.15.2 and V0.16.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.16/0.16.md).
+
+<!-- ==== END OF TOPIC ==== version0.15.md ==== -->

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -23,7 +23,7 @@
 -->
 
 
-# What's new in version 0.6
+# What's new in version 0.16
 
  The following new features and notable changes since v.0.15.2 are included in this release:
 

--- a/docs/xxusegcstartuphints.md
+++ b/docs/xxusegcstartuphints.md
@@ -32,8 +32,8 @@ When this option is enabled, the VM calculates, over several application restart
 
 | Setting                            | Effect  | Default                                                                            |
 |------------------------------------|---------|:----------------------------------------------------------------------------------:|
-| `-XX:+UseGCStartupHints` | Enable  |                                                                                              |
-| `-XX:-UseGCStartupHints` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>               |
+| `-XX:+UseGCStartupHints` | Enable  | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-XX:-UseGCStartupHints` | Disable |               |
 
 When enabled, the VM records the heap size when a *startup complete* event occurs, storing the value into the shared classes cache.
 On subsequent restarts, the garbage collector (GC) reads this value early in startup processing and expands the heap to an appropriate

--- a/docs/xxusegcstartuphints.md
+++ b/docs/xxusegcstartuphints.md
@@ -49,6 +49,10 @@ You can check the value used by the garbage collector for heap expansion by insp
 
 The final value stored to the shared cache is not recorded in the verbose GC output.
 
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
+- When enabled, this option overrides any initial heap size that is specified on the command line, for example by using the [`-Xms`](xms.md) option.
+- Because the shared classes cache is used to store heap size information, this option does not work if [shared classes](shrc.md) are disabled.
+
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This feature is not currently available with the Balanced GC policy.
 
 

--- a/docs/xxusegcstartuphints.md
+++ b/docs/xxusegcstartuphints.md
@@ -50,6 +50,7 @@ You can check the value used by the garbage collector for heap expansion by insp
 The final value stored to the shared cache is not recorded in the verbose GC output.
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
+
 - When enabled, this option overrides any initial heap size that is specified on the command line, for example by using the [`-Xms`](xms.md) option.
 - Because the shared classes cache is used to store heap size information, this option does not work if [shared classes](shrc.md) are disabled.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ pages:
     - "New to OpenJ9?"                                                           : openj9_newuser.md
 
     - "Release notes" :
+        - "Version 0.16.0"                                                       : version0.16.md    
         - "Version 0.15.1"                                                       : version0.15.md
         - "Version 0.14.0"                                                       : version0.14.md
         - "Version 0.13.0"                                                       : version0.13.md


### PR DESCRIPTION
- Create the What's New topic for 0.16.0 and add this update.
- Update the -XX:UseGCStartupHints topic.

See https://github.com/eclipse/openj9-docs/issues/324

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>

[skip ci]