### PR TITLE
Doc updates for bootstrap class sharing enabled by default

### DIFF
--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -38,6 +38,7 @@ Memory footprint is reduced by sharing common classes between applications that 
 ## Enabling class data sharing
 
 Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container. If you want to change the default behaviour, use the [`-Xshareclasses`](xshareclasses.md) option on the command line. For example:
+
 - You can change the name and location of the default shared classes cache.
 - You can enable messages about the default shared classes cache by using the default command line option without the `silent` suboption: `-Xshareclasses:bootClassesOnly,nonFatal`.
 

--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -37,16 +37,17 @@ Memory footprint is reduced by sharing common classes between applications that 
 
 ## Enabling class data sharing
 
-You enable class data sharing by setting the `-Xshareclasses` option on the command line when you start your application. By default, OpenJ9 always shares both the bootstrap and application classes that are loaded by the default system class loader.
+Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, for example you can change the name and location of the default shared classes cache.
 
-<!--
-  Class data sharing is enabled by default for bootstrap classes only, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, including the name and location of the default shared classes cache. Trace point `j9shr.2271` is activated if the default cache cannot be started, so you can enable this trace point to determine whether the default cache started successfully. You can treat the default cache like any other shared classes cache, for example you can print statistics for it, change the soft maximum limit size, or delete it. Note that if you have multiple VMs and you do not change the default shared classes behavior, the VMs will share a single default cache, assuming that the VMs are from a single Java installation. If the VMs are from different Java installations, the cache might be deleted and recreated; for more information, see the following section about best practices. -->
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you have multiple VMs and you do not change the default shared classes behavior, the VMs will share a single default cache, assuming that the VMs are from a single Java installation. If the VMs are from different Java installations, the cache might be deleted and recreated; for more information, see the following section about best practices.
 
-The [-Xshareclasses](xshareclasses.md) option is highly configurable, allowing you to specify where to create the cache, how much space to allocate for AOT code and more. You can also set the cache size by using the [-Xscmx](xscmx.md) option.
+Trace point `j9shr.2271` is activated if the default cache cannot be started, so you can enable this trace point to determine whether the default cache started successfully.
+
+You can treat the default cache like any other shared classes cache, for example you can print statistics for it, change the soft maximum limit size, or delete it.
 
 ## Best practices for using `-Xshareclasses`
 
-When you explicitly set the [-Xshareclasses](xshareclasses.md) option, it is good practice to set a number of parameters on the option:
+The [-Xshareclasses](xshareclasses.md) option is highly configurable, allowing you to specify where to create the cache, how much space to allocate for AOT code and more. You can also set the cache size by using the [-Xscmx](xscmx.md) option. When shared classes is enabled, it is good practice to specify some of the cache behavior:
 
 - Set an application-specific cache name ([`-Xshareclasses:name=<name>`](xshareclasses.md#name)).
 

--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -37,11 +37,15 @@ Memory footprint is reduced by sharing common classes between applications that 
 
 ## Enabling class data sharing
 
-Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container. You can use the [`-Xshareclasses`](xshareclasses.md) option to change the default behavior, for example you can change the name and location of the default shared classes cache. To enable class data sharing for non-bootstrap classes as well, use `-Xshareclasses` without the `bootClassesOnly` suboption. You can also disable all class data sharing by using the `none` suboption.
+Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container. If you want to change the default behaviour, use the [`-Xshareclasses`](xshareclasses.md) option on the command line. For example:
+- You can change the name and location of the default shared classes cache.
+- You can enable messages about the default shared classes cache by using the default command line option without the `silent` suboption: `-Xshareclasses:bootClassesOnly,nonFatal`.
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you have multiple VMs and you do not change the default shared classes behavior, the VMs will share a single default cache, assuming that the VMs are from a single Java installation. If the VMs are from different Java installations, the cache might be deleted and recreated; for more information, see the following section about best practices.
 
 You can treat the default cache like any other shared classes cache, for example you can print statistics for it, change the soft maximum limit size, or delete it.
+
+You can enable class data sharing for non-bootstrap classes as well, by using `-Xshareclasses` without the `bootClassesOnly` suboption. You can also disable all class data sharing by using the `none` suboption.
 
 ## Best practices for using `-Xshareclasses`
 

--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -37,11 +37,9 @@ Memory footprint is reduced by sharing common classes between applications that 
 
 ## Enabling class data sharing
 
-Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, for example you can change the name and location of the default shared classes cache.
+Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container. You can use the [`-Xshareclasses`](xshareclasses.md) option to change the default behavior, for example you can change the name and location of the default shared classes cache. To enable class data sharing for non-bootstrap classes as well, use `-Xshareclasses` without the `bootClassesOnly` suboption. You can also disable all class data sharing by using the `none` suboption.
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you have multiple VMs and you do not change the default shared classes behavior, the VMs will share a single default cache, assuming that the VMs are from a single Java installation. If the VMs are from different Java installations, the cache might be deleted and recreated; for more information, see the following section about best practices.
-
-Trace point `j9shr.2271` is activated if the default cache cannot be started, so you can enable this trace point to determine whether the default cache started successfully.
 
 You can treat the default cache like any other shared classes cache, for example you can print statistics for it, change the soft maximum limit size, or delete it.
 

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -25,7 +25,7 @@
 
 # What's new in version 0.16
 
- The following new features and notable changes since v.0.15.2 are included in this release:
+The following new features and notable changes since v.0.15.2 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Some class data sharing is enabled by default](#some-class-data-sharing-is-enabled-by-default)
@@ -37,7 +37,7 @@
 
 ### Binaries and supported environments
 
- OpenJ9 release 0.16.0 supports OpenJDK 13, which is available from the AdoptOpenJDK community at the following link:
+OpenJ9 release 0.16.0 supports OpenJDK 13, which is available from the AdoptOpenJDK community at the following link:
 
 - [OpenJDK version 13](https://adoptopenjdk.net/archive.html?variant=openjdk13&jvmVariant=openj9)
 
@@ -45,15 +45,15 @@ OpenJDK 13 with Eclipse OpenJ9 is not a long term support (LTS) release.
 
 The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK community are for Eclipse OpenJ9 release 0.15.2. Features mentioned in these release notes are not available in these builds. Although it might be possible to build an OpenJDK 8 or OpenJDK 11 with OpenJ9 0.16.0, testing at the project is not complete and therefore support for any of these features is not available.
 
- To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
- ### Some class data sharing is enabled by default
+### Some class data sharing is enabled by default
 
- Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
+Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
 
 ### Automatic setting of initial heap size is enabled by default
 
- OpenJ9 version 0.15.1 introduced the [`-XX:[+|-]UseGCStartupHints`](xxusegcstartuphints.md) option, which, when enabled, turned on the automatic learning and setting of an appropriate heap size for an application. This option is now enabled by default.
+OpenJ9 version 0.15.1 introduced the [`-XX:[+|-]UseGCStartupHints`](xxusegcstartuphints.md) option, which, when enabled, turned on the automatic learning and setting of an appropriate heap size for an application. This option is now enabled by default.
 
 ## Full release information
 

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -49,7 +49,7 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 ### Some class data sharing is enabled by default
 
-Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
+Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, including using `-Xshareclasses:none` to disable all class data sharing. For more information, see [Class Data Sharing](shrc.md).
 
 ### Automatic setting of initial heap size is enabled by default
 

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -28,6 +28,7 @@
  The following new features and notable changes since v.0.15.2 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Some class data sharing is enabled by default](#some-class-data-sharing-is-enabled-by-default)
 - [Automatic setting of initial heap size is enabled by default](#automatic-setting-of-initial-heap-size-is-enabled-by-default)
 
 
@@ -45,6 +46,10 @@ OpenJDK 13 with Eclipse OpenJ9 is not a long term support (LTS) release.
 The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK community are for Eclipse OpenJ9 release 0.15.2. Features mentioned in these release notes are not available in these builds. Although it might be possible to build an OpenJDK 8 or OpenJDK 11 with OpenJ9 0.16.0, testing at the project is not complete and therefore support for any of these features is not available.
 
  To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+ ### Some class data sharing is enabled by default
+
+ Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior. For more information, see [Class Data Sharing](shrc.md).
 
 ### Automatic setting of initial heap size is enabled by default
 

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -57,6 +57,6 @@ OpenJ9 version 0.15.1 introduced the [`-XX:[+|-]UseGCStartupHints`](xxusegcstart
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.15.2 and V0.16.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.16/0.16.md).
+To see a complete list of changes between Eclipse OpenJ9 V0.15.1 and V0.16.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.16/0.16.md).
 
 <!-- ==== END OF TOPIC ==== version0.15.md ==== -->

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -49,7 +49,7 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 ### Some class data sharing is enabled by default
 
-Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, including using `-Xshareclasses:none` to disable all class data sharing. For more information, see [Class Data Sharing](shrc.md).
+Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container. You can use the `-Xshareclasses` option to change the default behavior, including using `-Xshareclasses:none` to disable all class data sharing. For more information, see [Class data sharing](shrc.md).
 
 ### Automatic setting of initial heap size is enabled by default
 

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -22,16 +22,11 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-
-
-
-
-
 # -Xshareclasses
 
-You can use the `-Xshareclasses` option to enable class sharing. This option can take a number of parameters, some of which are cache utilities.
+Use the `-Xshareclasses` option to enable, disable, or modify class sharing behavior. Class data sharing is enabled by default for bootstrap classes only (the equivalent of specifying `-Xshareclasses:bootClassesOnly,nonFatal,silent`), unless your application is running in a container.
 
-Cache utilities perform the required operation on the specified cache, without starting the VM. You can combine multiple suboptions, which are separated by commas, but the cache utilities are mutually exclusive.
+This option can take a number of parameters, some of which are cache utilities. Cache utilities perform the required operation on the specified cache, without starting the VM. You can combine multiple suboptions, which are separated by commas, but the cache utilities are mutually exclusive.
 
 When you are running cache utilities, the message `Could not create the Java virtual machine` is expected. Cache utilities do not create the virtual machine.
 


### PR DESCRIPTION
See https://github.com/eclipse/openj9-docs/issues/311

Signed-off-by: Esther Dovey doveye@uk.ibm.com

[skip ci]