### PR TITLE
Doc updates for shared classes cache generation number update

### DIFF
--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -30,6 +30,7 @@
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Automatic setting of initial heap size is enabled by default](#automatic-setting-of-initial-heap-size-is-enabled-by-default)
 - [Performance improvements for JVMTI watched fields on Power Systems](#performance-improvements-for-jvmti-watched-fields-on-power-systems)
+- [Changes to the shared classes cache generation number](#changes-to-the-shared-classes-cache-generation-number)
 
 
 
@@ -54,6 +55,13 @@ The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK c
 ### Performance improvements for JVMTI watched fields on Power Systems
 
 OpenJ9 version 0.14.0 introduced the [`-XX:[+|-]JITInlineWatches`](xxjitinlinewatches.md) option, which turns on JIT operations to improve the performance of JVMTI watched fields. This option, which was enabled by default in version 0.15.1, is now also supported on AIX&reg; and Linux on Power Systems&trade;.
+
+#### Changes to the shared classes cache generation number
+
+The format of classes that are stored in the shared classes cache is changed, which causes the JVM to create a new shared classes cache rather than re-creating or reusing an existing cache. To save space, you can remove all existing shared caches unless they are in use by an earlier release. As a result of the format change, a `layer` column now appears in the output of the `-Xshareclasses:listAllCaches` option. This change is to support a future enhancement.
+
+For more information about the `-Xshareclasses` option, including the `destroy` options that you can use to remove caches, see [`-Xshareclasses`](xshareclasses.md).
+
 
 ## Full release information
 


### PR DESCRIPTION
Update the 0.16 release notes in the user docs

See https://github.com/eclipse/openj9-docs/issues/345

Signed-off-by: Esther Dovey doveye@uk.ibm.com

[skip ci]