### PR TITLE
Doc update: Message digest is enabled on Java 13

### DIFF
--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -42,7 +42,7 @@ OpenSSL support is enabled by default for the Digest, CBC, GCM, RSA, and ChaCha2
 
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
 
--  ![Start of content that applies to Java 8 (LTS) and later](cr/java8plus.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8 and later)](cr/java_close_lts.png)
+-  ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8, 11, and 12)](cr/java_close_lts.png)
 -  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
 
 If you want to turn off the algorithms individually, use the following system properties:

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -26,8 +26,8 @@
 
 This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS) and later](cr/java8plus.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled.
-This option cannot be used to turn on Digest support. ![End of content that applies to Java 8 and later](cr/java_close_lts.png)
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled.
+This option cannot be used to turn on Digest support. ![End of content that applies to Java 8, 11, and 12](cr/java_close_lts.png)
 
 ## Syntax
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -71,7 +71,7 @@ OpenJDK uses the in-built Java cryptographic implementation by default. However,
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
 Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.0.x and V1.1.x implementations are currently supported for the Digest, CBC, GCM, and RSA algorithms. The OpenSSL V1.1.x implementation is also supported for the ChaCha20 and ChaCha20-Poly1305 algorithms.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 and later](cr/java8plus.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8 and later)](cr/java_close_lts.png)
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8, 11, and 12)](cr/java_close_lts.png)
 
 On Linux and AIX platforms, the OpenSSL 1.0.x or 1.1.x library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.x library is currently bundled with the binaries from AdoptOpenJDK.
 


### PR DESCRIPTION
Change disabled restriction from applying to Java 8+ to Java 8, Java 11, and Java 12. When we have the archive doc package for 0.16.0, this text will need to change again as message digest will be enabled for all Java levels.

https://github.com/eclipse/openj9-docs/issues/353

Signed-off-by: Esther Dovey doveye@uk.ibm.com

[skip ci]