### PR TITLE
Doc update: Message digest is re-enabled for all levels of Java

### DIFF
--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -40,10 +40,7 @@ This option controls the use of OpenSSL native cryptographic support.
 
 OpenSSL support is enabled by default for the Digest, CBC, GCM, RSA, and ChaCha20 and ChaCha20-Poly1305 algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
-
--  ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8, 11, and 12)](cr/java_close_lts.png)
--  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:**  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
 
 If you want to turn off the algorithms individually, use the following system properties:
 

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -26,17 +26,14 @@
 
 This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled.
-This option cannot be used to turn on Digest support. ![End of content that applies to Java 8, 11, and 12](cr/java_close_lts.png)
-
 ## Syntax
 
         -Djdk.nativeDigest=[true|false]
 
 | Setting              | value    | Default                                                                        |
 |----------------------|----------|:------------------------------------------------------------------------------:|
-| `-Djdk.nativeDigest` | true     |                                                                                |
-| `-Djdk.nativeDigest` | false    | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-Djdk.nativeDigest` | true     | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| `-Djdk.nativeDigest` | false    |  |
 
 ## Explanation
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -71,8 +71,6 @@ OpenJDK uses the in-built Java cryptographic implementation by default. However,
 typically provide better performance. OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and
 Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. The OpenSSL V1.0.x and V1.1.x implementations are currently supported for the Digest, CBC, GCM, and RSA algorithms. The OpenSSL V1.1.x implementation is also supported for the ChaCha20 and ChaCha20-Poly1305 algorithms.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8, 11, and 12)](cr/java_close_lts.png)
-
 On Linux and AIX platforms, the OpenSSL 1.0.x or 1.1.x library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On other platforms, the OpenSSL 1.1.x library is currently bundled with the binaries from AdoptOpenJDK.
 
 OpenSSL support is enabled by default for all supported algorithms. If you want to limit support to specific algorithms, a number of
@@ -80,7 +78,7 @@ system properties are available for tuning the implementation.
 
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
-- To turn off **Digest**, set `-Djdk.nativeDigest=false` (See **Restriction**. This system property cannot be used to enable the Digest algorithm)
+- To turn off **Digest**, set `-Djdk.nativeDigest=false`
 - To turn off **ChaCha20** and **ChaCha20-Poly1305**, set `-Djdk.nativeChaCha20=false`. <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) These algorithms are not supported on Java 8 or 12![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
 - To turn off **CBC**, set `-Djdk.nativeCBC=false`
 - To turn off **GCM**, set `-Djdk.nativeGCM=false`

--- a/docs/version0.17.md
+++ b/docs/version0.17.md
@@ -1,0 +1,53 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# What's new in version 0.17
+
+The following new features and notable changes since v.0.16 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Digest algorithm is re-enabled](#digest-algorithm-is-re-enabled)
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.17.0 supports OpenJDK 8, 11, and 13. Binaries are available from the AdoptOpenJDK community at the following links:
+
+- [OpenJDK version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK version 13](https://adoptopenjdk.net/archive.html?variant=openjdk13&jvmVariant=openj9)
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Digest algorithm is re-enabled
+
+Issue [#5611](https://github.com/eclipse/openj9/issues/5611) is fixed, so support for the Digest algorithm is re-enabled. For more information about this support, see [Cryptographic operations]( introduction.md#cryptographic-operations).
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 V0.16 and V0.17.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.17/0.17.md).
+
+<!-- ==== END OF TOPIC ==== version0.17.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,11 +102,12 @@ pages:
     - "New to OpenJ9?"                                                           : openj9_newuser.md
 
     - "Release notes" :
+        - "Version 0.17.0"                                                       : version0.17.md
         - "Version 0.16.0"                                                       : version0.16.md    
         - "Version 0.15.1"                                                       : version0.15.md
         - "Version 0.14.0"                                                       : version0.14.md
-        - "Version 0.13.0"                                                       : version0.13.md
         - "Earlier releases" :
+            - "Version 0.13.0"                                                   : version0.13.md        
             - "Version 0.12.0"                                                   : version0.12.md
             - "Version 0.11.0"                                                   : version0.11.md
             - "Version 0.10.0"                                                   : version0.10.md


### PR DESCRIPTION
Change 3 topics that mention message digest to remove the restriction where it was disabled for Java releases earlier than 13.
Also add a What's New section for this change.

https://github.com/eclipse/openj9-docs/issues/353

Signed-off-by: Esther Dovey doveye@uk.ibm.com

[skip ci]