### PR TITLE
Remove OpenJDK 12 references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,8 +133,8 @@ The user documentation supports the configuration, tuning, and diagnosis of the 
 - ![Java 8 icon](docs/cr/java8.png) - For content that applies only to an OpenJDK version 8.
 - ![Java 11 icon](docs/cr/java11.png) - For content that applies only to an OpenJDK version 11.
 - ![Java 11 and later icon](docs/cr/java11plus.png) -  For content that applies to an OpenJDK version 11 or later version.
-- ![Java 12 icon](docs/cr/java12.png) - For content that applies only to an OpenJDK version 12.
-- ![Java 12 and later icon](docs/cr/java12plus.png) -  For content that applies to an OpenJDK version 12 or later version.
+- ![Java 13 icon](docs/cr/java13.png) - For content that applies only to an OpenJDK version 13.
+- ![Java 13 and later icon](docs/cr/java13plus.png) -  For content that applies to an OpenJDK version 13 or later version.
 
 Different colors are used for the icons to differentiate long term service (LTS) releases from feature releases. For accessibility reasons it is important to use alternative text with these icons that differentiates an LTS release.
 
@@ -151,7 +151,7 @@ Here are some examples:
 ```
 
 ```
-![Start of content that applies only to Java 10 and later](cr/java10plus.png) This sentence applies only to Java 9 or later runtime environments that include the OpenJ9 VM. ![End of content that applies only to Java 10 and later](cr/java_close.png)
+![Start of content that applies only to Java 13 and later](cr/java13plus.png) This sentence applies only to Java 13 or later runtime environments that include the OpenJ9 VM. ![End of content that applies only to Java 13 and later](cr/java_close.png)
 ```
 
 ### Using images
@@ -185,7 +185,7 @@ Font-awesome icons are also used in option tables to indicate defaults. The foll
 
 Note that these require an extra `<span>`, which is used by screen readers.
 
-For examples that embed Java version icons such as ![Java 8 icon](docs/cr/java8.png) and ![Java 12 and later icon](docs/cr/java12plus.png), see [Which OpenJDK version?](#which-openjdk-version?).
+For examples that embed Java version icons such as ![Java 8 icon](docs/cr/java8.png) and ![Java 13 and later icon](docs/cr/java13plus.png), see [Which OpenJDK version?](#which-openjdk-version?).
 
 ### Accessibility
 

--- a/docs/adoptopenjdk.md
+++ b/docs/adoptopenjdk.md
@@ -8,7 +8,7 @@ following links:
 
 - [OpenJDK8 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9)
 - [OpenJDK11 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9)
-- [OpenJDK12 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk12&jvmVariant=openj9)
+- [OpenJDK13 with OpenJ9](https://adoptopenjdk.net/releases.html?variant=openjdk13&jvmVariant=openj9)
 
 Nightly builds of OpenJDK with OpenJ9 are also available from the project.
 

--- a/docs/djdknativechacha20.md
+++ b/docs/djdknativechacha20.md
@@ -28,7 +28,7 @@ This option enables or disables OpenSSL native cryptographic support for the Cha
 
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
 
-- ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12](cr/java12.png) These algorithms are not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12](cr/java_close_lts.png)
+- ![Start of content that applies to Java 8 (LTS)](cr/java8.png) These algorithms are not supported on Java 8. ![End of content that applies only to Java 8](cr/java_close_lts.png)
 - These algorithms are not supported on OpenSSL 1.0.x.
 
 

--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -43,12 +43,12 @@ OpenSSL support is enabled by default for the Digest, CBC, GCM, RSA, and ChaCha2
 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restrictions:**
 
 -  ![Start of content that applies to Java 8 (LTS)](cr/java8.png)![Start of content that applies to Java 11 (LTS)](cr/java11.png)![Start of content that applies to Java 12](cr/java12.png) Due to issue [#5611](https://github.com/eclipse/openj9/issues/5611), the Digest algorithm is currently disabled. ![End of content that applies to Java 8, 11, and 12)](cr/java_close_lts.png)
--  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
+-  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java 8. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
 If you want to turn off the algorithms individually, use the following system properties:
 
 - [`-Djdk.nativeCBC`](djdknativecbc.md)
-- [`-Djdk.nativeChaCha20`](djdknativechacha20.md) (![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) Not supported on Java 8 or 12. ![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png))
+- [`-Djdk.nativeChaCha20`](djdknativechacha20.md) (![Start of content that applies to Java 8 (LTS)](cr/java8.png) Not supported on Java 8. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png))
 - [`-Djdk.nativeGCM`](djdknativegcm.md)
 - [`-Djdk.nativeRSA`](djdknativersa.md)
 - [`-Djdk.nativeDigest`](djdknativedigest.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ This user documentation supports the configuration, tuning, and diagnosis of the
 
 ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) This sentence applies only to Java 8 binaries that include the OpenJ9 VM. Icons for LTS releases are this colour. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
-![Start of content that applies only to Java 12 and later](cr/java12plus.png) This sentence applies only to Java 12 or later binaries that include the OpenJ9 VM. Icons for feature releases are this colour. ![End of content that applies only to Java 12 or later](cr/java_close.png)
+![Start of content that applies only to Java 13 and later](cr/java13plus.png) This sentence applies only to Java 13 or later binaries that include the OpenJ9 VM. Icons for feature releases are this colour. ![End of content that applies only to Java 13 or later](cr/java_close.png)
 
 To see which Java releases are LTS releases and which are feature releases, and for information about release cadence, supported platforms, and build environments, see [Supported environments](openj9_support.md).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -81,7 +81,7 @@ system properties are available for tuning the implementation.
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
 - To turn off **Digest**, set `-Djdk.nativeDigest=false` (See **Restriction**. This system property cannot be used to enable the Digest algorithm)
-- To turn off **ChaCha20** and **ChaCha20-Poly1305**, set `-Djdk.nativeChaCha20=false`. <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 12 (LTS)](cr/java12.png) These algorithms are not supported on Java 8 or 12![End of content that applies only to Java 8 and 12 (LTS)](cr/java_close_lts.png)
+- To turn off **ChaCha20** and **ChaCha20-Poly1305**, set `-Djdk.nativeChaCha20=false`. <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) These algorithms are not supported on Java 8. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 - To turn off **CBC**, set `-Djdk.nativeCBC=false`
 - To turn off **GCM**, set `-Djdk.nativeGCM=false`
 - To turn off **RSA**, set `-Djdk.nativeRSA=false`
@@ -96,7 +96,7 @@ To build a version of OpenJDK with OpenJ9 that includes OpenSSL support, follow 
 
 - [OpenJDK 8 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V8.md).
 - [OpenJDK 11 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V11.md).
-- [OpenJDK 12 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V12.md).
+- [OpenJDK 13 with OpenJ9](https://github.com/eclipse/openj9/blob/master/doc/build-instructions/Build_Instructions_V13.md).
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you obtain an OpenJDK with OpenJ9 build from [AdoptOpenJDK](https://adoptopenjdk.net/) that includes OpenSSL or build a version yourself that includes OpenSSL support, the following acknowledgements apply in accordance with the license terms:
 

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -33,7 +33,7 @@ Eclipse OpenJ9 against a supported OpenJDK level, with fixes being delivered in 
 
 In order to track the OpenJDK 6 month release cadence, OpenJ9 also produces two releases a year that support only
 a single JDK level.  These releases will occur in March and September with the intention of supporting only
-the corresponding new OpenJDK feature release (ie: 11, 12, ...).
+the corresponding new OpenJDK feature release (ie: 11, 13, ...).
 
 The following table summarizes which JDK levels are expected to be supported by which Eclipse OpenJ9 releases,
 along with projected release dates. All future dates and support expectations are predictions that might change
@@ -43,16 +43,16 @@ columns will be removed over time.
 
 ## Eclipse OpenJ9 releases
 
-| OpenJ9 release  | Release date        | JDK8 (LTS)| JDK11 (LTS) | JDK12    | JDK13     | JDK14     |
-|-----------------|---------------------|-----------|-------------|----------|-----------|-----------|
-| v0.12.0         | January 2019        | Yes       | Yes         |          |           |           |
-| v0.13.0         | March 2019          | No        | No          | Yes (\*2)|           |           |
-| v0.14.0         | April 2019          | Yes       | Yes         | Yes      |           |           |
-| v0.15.0         | July 2019           | Yes       | Yes         | Yes      |           |           |
-| v0.16.0         | September 2019      | No        | No          | No       | Yes (\*2) |           |
-| v0.17.0         | October 2019 (\*1)  | Yes       | Yes         | No       | Yes       |           |
-| v0.18.0         | January 2020 (\*1)  | Yes       | Yes         | No       | Yes       |           |
-| v0.19.0         | March 2020 (\*1)    | No        | No          | No       | No        | Yes (\*2) |
+| OpenJ9 release  | Release date        | JDK8 (LTS)| JDK11 (LTS) | JDK13     | JDK14     |
+|-----------------|---------------------|-----------|-------------|-----------|-----------|
+| v0.12.0         | January 2019        | Yes       | Yes         |           |           |
+| v0.13.0         | March 2019          | No        | No          |           |           |
+| v0.14.0         | April 2019          | Yes       | Yes         |           |           |
+| v0.15.0         | July 2019           | Yes       | Yes         |           |           |
+| v0.16.0         | September 2019      | No        | No          | Yes (\*2) |           |
+| v0.17.0         | October 2019        | Yes       | Yes         | Yes       |           |
+| v0.18.0         | January 2020 (\*1)  | Yes       | Yes         | Yes       |           |
+| v0.19.0         | March 2020 (\*1)    | No        | No          | No        | Yes (\*2) |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
 
@@ -151,47 +151,6 @@ minimum glibc version 2.12 are expected to function without problems.
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
-### OpenJDK 12
-
-<i class="fa fa-bell" aria-hidden="true"></i> **Important:** If you obtain pre-built binaries from [AdoptOpenJDK.net](https://adoptopenjdk.net/index.html),
-platform support might vary, depending on their build environment. Check the AdoptOpenJDK [Platform support matrix](https://adoptopenjdk.net/supported_platforms.html).
-
-OpenJDK12 binaries are supported on the minimum operating system levels shown in the following tables:
-
-
-| Linux                                 |  x64   |  ppc64le   | Z64  |
-|---------------------------------------|--------|------------|------|
-| Centos 6.9                            |   Y    |     Y      |  N   |
-| Centos 7.4                            |   Y    |     Y      |  N   |
-| Red Hat Enterprise Linux (RHEL) 6.9   |   Y    |     Y      |  Y   |
-| RHEL 7.4                              |   Y    |     Y      |  Y   |
-| SUSE Linux Enterprise Server (SLES) 12|   Y    |     Y      |  Y   |
-| Ubuntu 16.04                          |   Y    |     Y      |  Y   |
-| Ubuntu 18.04                          |   Y    |     Y      |  Y   |
-
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Not all of these distributions are tested, but Linux distributions that have a
-minimum glibc version 2.12 are expected to function without problems.
-
-| Windows                    |  x64   |
-|----------------------------|--------|
-| Windows 7 SP1              |   Y    |
-| Windows 8                  |   Y    |
-| Windows 8.1                |   Y    |
-| Windows 10                 |   Y    |
-| Windows Server 2012        |   Y    |
-| Windows Server 2012 R2     |   Y    |
-| Windows Server 2016        |   Y    |
-
-| macOS                   |   x64    |
-|-------------------------|----------|
-| OS X 10.9.0+            |    Y     |
-
-| AIX          |  ppc64   |
-|--------------|----------|
-| AIX 7.1 TL4  |    Y     |
-| AIX 7.2      |    Y     |
-
-When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
 ### OpenJDK 13
 
@@ -253,17 +212,6 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 | AIX POWER BE 64-bit                         | AIX 7.1 TL04              | xlc/C++ 13.1.3                  |
 
 ### OpenJDK 11
-
-| Platform                    | Operating system         |  Compiler                       |
-|-----------------------------|--------------------------|---------------------------------|
-| Linux x86 64-bit            | Ubuntu 16.04             | gcc 7.3                         |
-| Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 7.3                         |
-| Linux on IBM Z 64-bit       | Ubuntu 16.04             | gcc 7.4                         |
-| Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2017    |
-| macOS x86 64-bit            | macOS 10.13.5            | xcode/clang 9.4                 |
-| AIX POWER BE 64-bit         | AIX 7.1 TL04             | xlc/C++ 13.1.3                  |
-
-### OpenJDK 12
 
 | Platform                    | Operating system         |  Compiler                       |
 |-----------------------------|--------------------------|---------------------------------|


### PR DESCRIPTION
OpenJDK 13 supersedes 12. Clean up docs to remove references to 12, including
icons.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>