### PR TITLE
Bring in minimal content for GPU processing

### DIFF
--- a/docs/adoptopenjdk.md
+++ b/docs/adoptopenjdk.md
@@ -21,8 +21,8 @@ range of platforms. For information about the platforms and minimum operating sy
 
 If you obtain binaries from the AdoptOpenJDK community, the following pre-requisites are required:
 
-- OpenJDK binaries for Linux and AIX platforms from the AdoptOpenJDK community no longer bundle the OpenSSL cryptographic library. The library is expected to be found on the system path. If you want to use OpenSSL cryptographic acceleration, you must install OpenSSL 1.0.2 or 1.1.X on your system. If the library is not found on the system path, the in-built Java crytographic implementation is used instead, which performs less well.  
+- From Eclipse OpenJ9 release 0.13.0, OpenJDK binaries for Linux and AIX platforms from the AdoptOpenJDK community no longer bundle the OpenSSL cryptographic library. The library is expected to be found on the system path. If you want to use OpenSSL cryptographic acceleration, you must install OpenSSL 1.0.2 or 1.1.X on your system. If the library is not found on the system path, the in-built Java crytographic implementation is used instead, which performs less well.  
 - ![Start of content that applies only to Java 8](cr/java8.png) On Linux systems, the `fontconfig.x86_64` package should be installed to avoid a `NullPointerException` error when the AWT font subsystem is initialized. Work is ongoing at the AdoptOpenJDK project to fix this issue for their OpenJDK binaries.
-
+- From Eclipse OpenJ9 release 0.16.0 (OpenJDK 13) and release 0.17.0 (OpenJDK 8 and 11), CUDA is now enabled on Windows (x86-64) and Linux (x86-64 and IBM POWER LE) platforms, which allows you to offload certain Java application processing tasks to a general purpose graphics processing unit (GPU). To take advantage of this feature, your system must support NVIDIA Compute Unified Device Architecture (CUDA). The JIT requires the CUDA Toolkit 7.5 and your GPU device must have a minimum compute capability of 3.0. 
 
 <!-- ==== END OF TOPIC ==== adoptopenjdk.md ==== -->

--- a/docs/dcomibmgpudisable.md
+++ b/docs/dcomibmgpudisable.md
@@ -1,0 +1,46 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Dcom.ibm.gpu.disable
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This system property is supported only on Java&trade; 11 and later
+
+If you have enabled GPU processing with `-Dcom.ibm.gpu.enable`, use this system property to turn off processing that can be offloaded to a graphics processing unit (GPU).
+
+## Syntax
+
+        -Dcom.ibm.gpu.disable
+
+
+## Explanation
+
+Because establishing and completing communication with a GPU incurs an additional overhead, not all processing requirements benefit from being offloaded to the GPU. GPU processing is therefore disabled by default. However, if you have enabled GPU processing with `-Dcom.ibm.gpu.enable`, this property turns GPU processing off.
+
+## See also
+
+- [Exploiting GPUs](introduction.md#exploiting-gpus)
+- [-Dcom.ibm.gpu.enable](dcomibmgpuenable.md)
+- [-Dcom.ibm.gpu.verbose](dcomibmgpuverbose.md)
+
+<!-- ==== END OF TOPIC ==== dcomibmgpudisable.md ==== -->

--- a/docs/dcomibmgpuenable.md
+++ b/docs/dcomibmgpuenable.md
@@ -1,0 +1,53 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Dcom.ibm.gpu.enable
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This system property is supported only on Java&trade; 11 and later
+
+Use this system property to control the type of processing that can be offloaded to a graphics processing unit (GPU) when processing requirements meet a specific threshold. This feature can improve the performance of certain Java functions.
+
+## Syntax
+
+        -Dcom.ibm.gpu.enable=[all|sort]
+
+| Setting      | Effect                                                      |
+|--------------|-------------------------------------------------------------|
+| all          | Turns on GPU processing for all possible Java functions.    |
+| sort         | Turns on GPU processing only for the Java `sort()` function.|
+
+By default, this property is not set.
+
+## Explanation
+
+Because establishing and completing communication with a GPU incurs an additional overhead, not all processing requirements benefit from being offloaded to the GPU. When set, this property enables GPU processing for any array that meets a minimum size.
+
+## See also
+
+- [Exploiting GPUs](introduction.md#exploiting-gpus)
+- [-Dcom.ibm.gpu.disable](dcomibmgpudisable.md)
+- [-Dcom.ibm.gpu.verbose](dcomibmgpuverbose.md)
+
+
+<!-- ==== END OF TOPIC ==== dcomibmgpuenable.md ==== -->

--- a/docs/dcomibmgpuverbose.md
+++ b/docs/dcomibmgpuverbose.md
@@ -1,0 +1,48 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -Dcom.ibm.gpu.verbose
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This system property is supported only on Java&trade; 11 and later
+
+This system property can be used to help identify problems with graphics processing unit (GPU) processing.
+
+## Syntax
+
+        -Dcom.ibm.gpu.verbose
+
+This property is not set by default.
+
+## Explanation
+
+When specified, this option generates verbose output to STDOUT, which can be piped to a file.
+
+## See also
+
+- [Exploiting GPUs](introduction.md#exploiting-gpus)
+- [-Dcom.ibm.gpu.disable](dcomibmgpudisable.md)
+- [-Dcom.ibm.gpu.enable](dcomibmgpuenable.md)
+
+
+<!-- ==== END OF TOPIC ==== dcomibmgpuverbose.md ==== -->

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -102,6 +102,11 @@ To build a version of OpenJDK with OpenJ9 that includes OpenSSL support, follow 
 - *This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. (http://www.openssl.org/).*
 - *This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).*
 
+### Exploiting GPUs
+
+OpenJ9 provides the [CUDA4J API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.cuda/index.html?view=kc) and the [com.ibm.gpu API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.gpu/index.html?view=kc), which allow you to develop applications that can take advantage of graphics processing unit (GPU) processing for suitable functions, such as code page conversion. You can also enable the JIT compiler to offload certain processing tasks to a GPU by specifying the `-Xjit:enableGPU` option on the command line. When enabled, the JIT compiler determines when to offload tasks based on performance heuristics.
+
+GPU processing is supported only on Windows (x86-64) and Linux (x86-64 and IBM Power LE) systems. For more information about enabling GPU processing, see [Exploiting graphics processing units](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.80.doc/docs/gpu_overview.html).
 
 ## Runtime options
 

--- a/docs/xjit.md
+++ b/docs/xjit.md
@@ -47,6 +47,7 @@ These parameters can be used to modify the behavior of `-Xjit`:
 |-------------------------------------|-----------------------------------------------------------------------------------------|
 | [`count`         ](#count         ) | Forces compilation of methods on first invocation.                                      |
 | [`disableRMODE64`](#disablermode64) | Allows the JIT to allocate executable code caches above the 2 GB memory bar.            |
+| [`enableGPU`     ](#enablegpu     ) | Allows the JIT to offload certain processing tasks to a graphics processing unit (GPU)  |
 | [`exclude`       ](#exclude       ) | Excludes the specified method from compilation.                                         |
 | [`<limitFile>`   ](#limitfile     ) | Compile methods that are listed in the limit file.                                      |
 | [`optlevel`      ](#optlevel      ) | Forces the JIT compiler to compile all methods at a specific optimization level.        |
@@ -66,6 +67,18 @@ These parameters can be used to modify the behavior of `-Xjit`:
         -Xjit:disableRMODE64
 
 : From z/OS V2R3, residency mode for 64-bit applications (RMODE64) is enabled by default. This feature allows the JIT to allocate executable code caches above the 2 GB memory bar, which is the default behavior. Use this option to turn off this JIT behavior.
+
+### `enableGPU`
+
+**(Windows (x86-64) or Linux (x86-64 and IBM POWER LE))**
+
+        -Xjit:enableGPU
+
+: Enables the JIT compiler to offload certain processing tasks to a graphics processing unit (GPU). The JIT determines which functions to offload based on performance heuristics. Systems must support NVIDIA Compute Unified Device Architecture (CUDA).  The JIT requires the CUDA Toolkit 7.5 and your GPU device must have a minimum compute capability of 3.0.
+
+: To troubleshoot operations between the JIT compiler and the GPU, use `-Xjit:enableGPU={verbose}`, which provides output showing the processing tasks that are offloaded and their status. To send this output to a file (`output.txt`), run `-Xjit:enableGPU={verbose},vlog=output.txt` when you start your application.
+
+: The `-Xjit:enableGPU={enforce}` option can be used to ensure that all `Parallel().ForEach()` invocations that are recognized by the JIT are offloaded to the GPU. The `enforce` option stops the JIT checking performance heuristics to determine whether a data processing task might benefit from processing on the GPU instead of the CPU. This action helps you validate that operations between the JIT compiler and the GPU can proceed successfully. You can also include verbose logging by specifying `-Xjit:enableGPU={enforce|verbose}` for detailed information about the processing tasks.
 
 ### `exclude`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,11 +103,11 @@ pages:
 
     - "Release notes" :
         - "Version 0.17.0"                                                       : version0.17.md
-        - "Version 0.16.0"                                                       : version0.16.md    
+        - "Version 0.16.0"                                                       : version0.16.md
         - "Version 0.15.1"                                                       : version0.15.md
         - "Version 0.14.0"                                                       : version0.14.md
         - "Earlier releases" :
-            - "Version 0.13.0"                                                   : version0.13.md        
+            - "Version 0.13.0"                                                   : version0.13.md
             - "Version 0.12.0"                                                   : version0.12.md
             - "Version 0.11.0"                                                   : version0.11.md
             - "Version 0.10.0"                                                   : version0.10.md
@@ -172,7 +172,9 @@ pages:
             - "-Dcom.ibm.enableLegacyDumpSecurity"                               : dcomibmenablelegacydumpsecurity.md
             - "-Dcom.ibm.enableLegacyLogSecurity"                                : dcomibmenablelegacylogsecurity.md
             - "-Dcom.ibm.enableLegacyTraceSecurity"                              : dcomibmenablelegacytracesecurity.md
-            - "-Dcom.ibm.lang.management.OperatingSystemMXBean.isCpuTime100ns"   : dcomibmlangmanagementosmxbeaniscputime100ns.md
+            - "-Dcom.ibm.gpu.disable"                                            : dcomibmgpudisable.md
+            - "-Dcom.ibm.gpu.enable"                                             : dcomibmgpuenable.md
+            - "-Dcom.ibm.gpu.verbose"                                            : dcomibmgpuverbose.md
             - "-Dcom.ibm.lang.management.verbose"                                : dcomibmlangmanagementverbose.md
             - "-Dcom.ibm.tools.attach.directory"                                 : dcomibmtoolsattachdirectory.md
             - "-Dcom.ibm.tools.attach.displayName"                               : dcomibmtoolsattachdisplayname.md


### PR DESCRIPTION
Now that CUDA enabled builds are available at AdoptOpenJDK, we should
have some information in OpenJ9 about how to take advantage of GPU
processing.

Minimal content included in this PR. Requires links to be added

Closes: #49 
Closes: #359

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>