### PR TITLE
Doc update: Shared classes cache layers 2

### DIFF
--- a/docs/dump_javadump.md
+++ b/docs/dump_javadump.md
@@ -635,6 +635,97 @@ NULL
 NULL
 ```
 
+The following example shows information for a layered cache:
+
+```
+NULL           ------------------------------------------------------------------------
+0SECTION       SHARED CLASSES subcomponent dump routine
+NULL           ========================================
+NULL
+1SCLTEXTCSTL   Cache Statistics for Top Layer
+NULL
+1SCLTEXTCRTW       Cache Created With
+NULL               ------------------
+NULL
+2SCLTEXTXNL            -Xnolinenumbers       = false
+2SCLTEXTBCI            BCI Enabled           = true
+2SCLTEXTBCI            Restrict Classpaths   = false
+NULL
+1SCLTEXTCSUM       Cache Summary
+NULL               ------------------
+NULL
+2SCLTEXTNLC            No line number content                    = false
+2SCLTEXTLNC            Line number content                       = false
+NULL
+2SCLTEXTRCS            ROMClass start address                    = 0x00007F0EDB567000
+2SCLTEXTRCE            ROMClass end address                      = 0x00007F0EDB567000
+2SCLTEXTMSA            Metadata start address                    = 0x00007F0EDC40241C
+2SCLTEXTCEA            Cache end address                         = 0x00007F0EDC54B000
+2SCLTEXTRTF            Runtime flags                             = 0x80102001ECA602BB
+2SCLTEXTCGN            Cache generation                          = 41
+NULL
+2SCLTEXTCLY            Cache layer                               = 1
+2SCLTEXTCSZ            Cache size                                = 16776608
+2SCLTEXTSMB            Softmx bytes                              = 16776608
+2SCLTEXTFRB            Free bytes                                = 15315996
+2SCLTEXTARB            Reserved space for AOT bytes              = -1
+2SCLTEXTAMB            Maximum space for AOT bytes               = -1
+2SCLTEXTJRB            Reserved space for JIT data bytes         = -1
+2SCLTEXTJMB            Maximum space for JIT data bytes          = -1
+2SCLTEXTRWB            ReadWrite bytes                           = 114080
+2SCLTEXTDAS            Class debug area size                     = 1331200
+2SCLTEXTDAU            Class debug area % used                   = 0%
+2SCLTEXTDAN            Class LineNumberTable bytes               = 0
+2SCLTEXTDAV            Class LocalVariableTable bytes            = 0
+NULL
+2SCLTEXTCPF            Cache is 8% full
+NULL
+1SCLTEXTCMST       Cache Memory Status
+NULL               ------------------
+1SCLTEXTCNTD           Cache Name                    Feature                  Memory type              Cache path
+NULL
+2SCLTEXTCMDT           Cache1                        CR                       Memory mapped file       /tmp/javasharedresources/C290M4F1A64P_Cache1_G41L01
+NULL
+1SCLTEXTCMST       Cache Lock Status
+NULL               ------------------
+1SCLTEXTCNTD           Lock Name                     Lock type                TID owning lock
+NULL
+2SCLTEXTCWRL           Cache write lock              File lock                Unowned
+2SCLTEXTCRWL           Cache read/write lock         File lock                Unowned
+NULL
+1SCLTEXTCSAL   Cache Statistics for All Layers
+NULL
+2SCLTEXTRCB            ROMClass bytes                            = 1459040
+2SCLTEXTAOB            AOT code bytes                            = 57624
+2SCLTEXTADB            AOT data bytes                            = 272
+2SCLTEXTAHB            AOT class hierarchy bytes                 = 1840
+2SCLTEXTATB            AOT thunk bytes                           = 632
+2SCLTEXTJHB            JIT hint bytes                            = 484
+2SCLTEXTJPB            JIT profile bytes                         = 0
+2SCLTEXTNOB            Java Object bytes                         = 0
+2SCLTEXTZCB            Zip cache bytes                           = 1134016
+2SCLTEXTSHB            Startup hint bytes                        = 0
+2SCLTEXTJCB            JCL data bytes                            = 0
+2SCLTEXTBDA            Byte data bytes                           = 0
+NULL
+2SCLTEXTNRC            Number ROMClasses                         = 503
+2SCLTEXTNAM            Number AOT Methods                        = 16
+2SCLTEXTNAD            Number AOT Data Entries                   = 1
+2SCLTEXTNAH            Number AOT Class Hierarchy                = 28
+2SCLTEXTNAT            Number AOT Thunks                         = 11
+2SCLTEXTNJH            Number JIT Hints                          = 15
+2SCLTEXTNJP            Number JIT Profiles                       = 0
+2SCLTEXTNCP            Number Classpaths                         = 1
+2SCLTEXTNUR            Number URLs                               = 0
+2SCLTEXTNTK            Number Tokens                             = 0
+2SCLTEXTNOJ            Number Java Objects                       = 0
+2SCLTEXTNZC            Number Zip Caches                         = 21
+2SCLTEXTNSH            Number Startup Hint Entries               = 0
+2SCLTEXTNJC            Number JCL Entries                        = 0
+2SCLTEXTNST            Number Stale classes                      = 0
+2SCLTEXTPST            Percent Stale classes                     = 0%
+```
+
 ### CLASSES
 
 The classes section shows information about class loaders. The first part is a summary that records each available class loader (`2CLTEXTCLLOADER`) followed by the number of libraries and classes that it loaded. This information is followed by a more detailed list of libraries (`1CLTEXTCLLIB`) and classes (`1CLTEXTCLLO`) that are loaded.

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -33,7 +33,7 @@ These utilities display information about the contents of a shared classes cache
 -Xshareclasses:printAllStats,name=<cache_name>
 ```
 
-Displays the contents of the cache in chronological order. You can use this output to see the history of updates that were made to the cache. For layered caches, this utility displays the contents of the cache in each layer \(to see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats)).
+Displays the contents of the cache in chronological order. You can use this output to see the history of updates that were made to the cache.
 
 Each entry in the output starts with a VM ID, so you can see which VM wrote the associated data. Here are example entries for various types of cache data, with explanations:
 
@@ -120,7 +120,9 @@ Each entry in the output starts with a VM ID, so you can see which VM wrote the 
 -Xshareclasses:printStats=<data_type1>[+<data_type2>][...],name=<cache_name>
 ```
 
-Displays summary information about the cache. For layered caches, this utility displays information about the cache in each layer (to see information for the top layer cache only, use [`printTopLayerStats`](#printtoplayerstats)). You can request more detail about items of a specific data type that are stored in the shared cache by using `printStats=<data_type>`. Use the plus symbol (+) to separate the data types. For example, use `printStats=romclass+url,name=myCache` to see information about `ROMClass` and `URL` items in all the layer caches of the cache called `myCache`. The valid data types are as follows (case insensitive):
+Displays summary information about the cache. For layered caches, some information is shown for the top layer cache only, and some is shown for all layers combined. To see information for the top layer cache only, use [`printTopLayerStats`](#printtoplayerstats).
+
+You can request more detail about items of a specific data type that are stored in the shared cache by using `printStats=<data_type>`. Use the plus symbol (+) to separate the data types. For example, use `printStats=romclass+url,name=myCache` to see information about `ROMClass` and `URL` items in all the layer caches of the cache called `myCache`. The valid data types are as follows (case insensitive):
 
 -   `help` (displays the list of valid data types)
 -   `all` (equivalent to `printAllStats`)
@@ -136,62 +138,66 @@ Displays summary information about the cache. For layered caches, this utility d
 -   `stale`
 -   `startuphint`
 
-Example output with summary information only:
+Example output for a two-layer cache, with summary information only:
 
 ```
+Current statistics for top layer of cache "myCache":
+
 Cache created with:
         -Xnolinenumbers                      = false
         BCI Enabled                          = true
-        Restrict Classpaths                  = true
+        Restrict Classpaths                  = false
         Feature                              = cr
 
 Cache contains only classes with line numbers
 
-base address                         = 0x00007F44FC8EA000
-end address                          = 0x00007F44FD8CE000
-allocation pointer                   = 0x00007F44FCA1E650
+base address                         = 0x00007F394E20B000
+end address                          = 0x00007F394F1EF000
+allocation pointer                   = 0x00007F394E221EA0
 
+cache layer                          = 1
 cache size                           = 16776608
-softmx bytes                         = 8388608
-free bytes                           = 5638158
-ROMClass bytes                       = 1263184
-AOT bytes                            = 20164
+softmx bytes                         = 16776608
+free bytes                           = 15228964
 Reserved space for AOT bytes         = -1
 Maximum space for AOT bytes          = -1
-JIT data bytes                       = 1120
 Reserved space for JIT data bytes    = -1
 Maximum space for JIT data bytes     = -1
-Zip cache bytes                      = 1149512
-Data bytes                           = 114080
-Metadata bytes                       = 22348
-Metadata % used                      = 0%
 Class debug area size                = 1331200
-Class debug area used bytes          = 179434
-Class debug area % used              = 13%
+Class debug area used bytes          = 7728
+Class debug area % used              = 0%
 
-# ROMClasses                         = 433
-# AOT Methods                        = 12
+Cache is 9% full
+
+Cache is accessible to current user = true
+---------------------------------------------------------
+
+Current statistics for all layers of cache "myCache":
+
+ROMClass bytes                       = 1478240
+AOT bytes                            = 38544
+JIT data bytes                       = 416
+Zip cache bytes                      = 1134016
+Startup hint bytes                   = 0
+
+# ROMClasses                         = 510
+# AOT Methods                        = 15
 # Classpaths                         = 1
 # URLs                               = 0
 # Tokens                             = 0
 # Zip caches                         = 21
+# Startup hints                      = 0
 # Stale classes                      = 0
 % Stale classes                      = 0%
-
-Cache is 32% soft full
-
-Cache is accessible to current user = true
 ```
 
-The `Cache created with` section indicates the options that were used when the cache was created. `BCI Enabled` relates to the `-Xshareclasses:enableBCI` option (enabled by default) and `Restrict Classpaths` relates to the `-Xshareclasses:restrictClasspaths` option. `Feature = cr` indicates that the cache is a 64-bit compressed references cache, as listed in [Creating, populating, monitoring, and deleting a cache](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_admin.html).
+The `Cache created with` section indicates the options that were used when the cache was created. `BCI Enabled` relates to the [`-Xshareclasses:enableBCI`](xshareclasses.md#enablebci) option (enabled by default) and `Restrict Classpaths` relates to the [`-Xshareclasses:restrictClasspaths`](xshareclasses.md#restrictclasspaths) option. `Feature = cr` indicates that the cache is a 64-bit compressed references cache, as described in [Creating, populating, monitoring, and deleting a cache](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_admin.html).
 
 Line number information for classes in the cache is then shown with one of the following messages:
 
-|Message|Explanation|
-|-------|-----------|
-|`Cache contains only classes with line numbers`|VM line number processing was enabled for all the classes that were stored in this shared cache (the `-Xlinenumbers` option is enabled by default). All classes in the cache contain line numbers if the original classes contained line number data.|
-|`Cache contains only classes without line numbers`|The `-Xnolinenumbers` option was used to disable VM line number processing for all the classes that were stored in this shared cache, so none of the classes contain line numbers.|
-|`Cache contains classes with line numbers and classes without line numbers`|VM line number processing was enabled for some classes and disabled for others (the `-Xnolinenumbers` option was specified when some of the classes were added to the cache).|
+- `Cache contains only classes with line numbers` : VM line number processing was enabled for all the classes that were stored in this shared cache (the `-Xlinenumbers` option is enabled by default). All classes in the cache contain line numbers if the original classes contained line number data.
+- `Cache contains only classes without line numbers` : The `-Xnolinenumbers` option was used to disable VM line number processing for all the classes that were stored in this shared cache, so none of the classes contain line numbers.
+- `Cache contains classes with line numbers and classes without line numbers` : VM line number processing was enabled for some classes and disabled for others (the `-Xnolinenumbers` option was specified when some of the classes were added to the cache).
 
 The following summary data is displayed:
 
@@ -249,13 +255,13 @@ The following summary data is displayed:
 #### `Class debug area % used`
 : The percentage of the Class Debug Area that contains data.
 
-#### `# ROMClasses`
+#### `ROMClasses`
 : The number of classes in the cache. The cache stores `ROMClasses` \(the class data itself, which is read-only\) and information about the location from which the classes were loaded. This information is stored in different ways, depending on the Java `SharedClassHelper` API that was used to store the classes. For more information, see [Using the Java Helper API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_helper.html).
 
-#### `# AOT methods`
-: Optionally, `ROMClass` methods can be compiled and the AOT code stored in the cache. The `# AOT methods` information shows the total number of methods in the cache that have AOT code compiled for them. This number includes AOT code for stale classes.
+#### `AOT methods`
+: Optionally, `ROMClass` methods can be compiled and the AOT code stored in the cache. The `AOT methods` information shows the total number of methods in the cache that have AOT code compiled for them. This number includes AOT code for stale classes.
 
-#### `# Classpaths`, `URLs`, and `Tokens`
+#### `Classpaths`, `URLs`, and `Tokens`
 : The number of class paths, URLs, and tokens in the cache. Classes stored from a `SharedClassURLClasspathHelper` are stored with a Classpath. Classes stored using a `SharedClassURLHelper` are stored with a URL. Classes stored using a `SharedClassTokenHelper` are stored with a Token. Most class loaders, including the bootstrap and application class loaders, use a `SharedClassURLClasspathHelper`. The result is that it is most common to see class paths in the cache.
 
 : The number of Classpaths, URLs, and Tokens stored is determined by a number of factors. For example, every time an element of a Classpath is updated, such as when a `.jar` file is rebuilt, a new Classpath is added to the cache. Additionally, if partitions or modification contexts are used, they are associated with the Classpath, URL, or Token. A Classpath, URL, or Token is stored for each unique combination of partition and modification context. For more information, see [SharedClassHelper partitions](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_rbm_partitions.html) and [Modification contexts](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_rbm_contexts.html).
@@ -280,11 +286,62 @@ The following summary data is displayed:
 
         % soft Full = (('Soft max bytes' - 'Free Bytes') * 100) / ('Soft max  bytes')
 
-For more information about the soft maximum size, see [`-Xscmx`](xscmx.md).
+: For more information about the soft maximum size, see [`-Xscmx`](xscmx.md).
 
 #### `Cache is accessible to current user`
 : Whether the current user can access the cache.
 
 ## `printTopLayerStats`
 
-Use this utility with a layered cache. This utility works in the same way as `printStats`, but shows information for the top layer cache only.
+Use this utility with a layered cache. This utility works in the same way as `printStats`, but shows information for the top layer cache only. For example:
+
+```
+Current statistics for cache "Cache1":
+
+Cache created with:
+        -Xnolinenumbers                      = false
+        BCI Enabled                          = true
+        Restrict Classpaths                  = false
+        Feature                              = cr
+
+Cache contains only classes with line numbers
+
+base address                         = 0x00007F2812EEA000
+end address                          = 0x00007F2813ECE000
+allocation pointer                   = 0x00007F2812F00EA0
+
+cache size                           = 16776608
+softmx bytes                         = 16776608
+free bytes                           = 15228964
+Reserved space for AOT bytes         = -1
+Maximum space for AOT bytes          = -1
+Reserved space for JIT data bytes    = -1
+Maximum space for JIT data bytes     = -1
+Data bytes                           = 114080
+Metadata bytes                       = 1664
+Metadata % used                      = 0%
+Class debug area size                = 1331200
+Class debug area used bytes          = 7728
+Class debug area % used              = 0%
+ROMClass bytes                       = 93856
+AOT bytes                            = 6768
+JIT data bytes                       = 76
+Zip cache bytes                      = 0
+Startup hint bytes                   = 0
+stale bytes                          = 0
+
+# ROMClasses                         = 33
+# AOT Methods                        = 2
+# Classpaths                         = 0
+# URLs                               = 0
+# Tokens                             = 0
+# Zip caches                         = 0
+# Startup hints                      = 0
+# Stale classes                      = 0
+% Stale classes                      = 0%
+
+
+Cache is 9% full
+
+Cache is accessible to current user = true
+```

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -1,0 +1,290 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# Shared classes cache diagnostic utilities
+
+These utilities display information about the contents of a shared classes cache. Run the utilities by specifying them as suboptions of `-Xshareclasses`. The utilities run on the default cache unless you specify a cache by adding the `name=<cache_name>` suboption.
+
+## `printAllStats`
+
+```
+-Xshareclasses:printAllStats
+-Xshareclasses:printAllStats,name=<cache_name>
+```
+
+Displays the contents of the cache in chronological order. You can use this output to see the history of updates that were made to the cache. For layered caches, this utility displays the contents of the cache in each layer \(to see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats)).
+
+Each entry in the output starts with a VM ID, so you can see which VM wrote the associated data. Here are example entries for various types of cache data, with explanations:
+
+### Class paths
+
+: This example shows one class path with 4 entries:
+
+        1: 0x2234FA6C CLASSPATH
+                /myVM/Apps/application1.jar
+                /myVM/Apps/application2.jar
+                /myVM/Apps/application3.jar
+                /myVM/Apps/application4.jar
+
+    - `1` : the ID of the VM that wrote this data.
+    - `0x2234FA6C` : the address where this data is stored.
+    - `CLASSPATH` : the type of data that was written.
+
+### ROMClasses
+
+: This example shows an entry for a single `ROMClass`:
+
+        1: 0x2234F7DC ROMCLASS: java/lang/Runnable at 0x213684A8
+                Index 1 in class path 0x2234FA6C
+
+    - `1` : the ID of the VM that wrote this data.
+    - `0x2234F7DC` : the address where the metadata about the class is stored.
+    - `ROMCLASS` : the type of data that was stored.
+    - `java/lang/Runnable` : the name of the class.
+    - `0x213684A8` : the address where the class was stored.
+    - `Index 1` : the index in the class path where the class was loaded from.
+    - `0x2234FA6C` : the address of the class path against which this class is stored.
+
+: Stale classes are marked with `!STALE!`. Any partition or modification context that is used when the class is stored is also shown.
+
+### AOT methods
+
+: This example shows an entry for one AOT-compiled method:
+
+        1: 0x540FBA6A AOT: loadConvert
+                for ROMClass java/util/Properties at 0x52345174
+
+    - `1` : the ID of the VM that wrote this data.
+    - `0x540FBA6A` : the address where the data is stored.
+    - `AOT` : the type of data that was stored.
+    - `loadConvert` : the method for which AOT-compiled code is stored.
+    - `java/util/Properties` : the class that contains the method.
+    - `0x52345174` : the address of the class that contains the method.
+
+: Stale methods are marked with `!STALE!`.
+
+### URLs and tokens
+
+: A `Token` is a string that is passed to the Java™ `SharedClassHelper` API. The output for these data types has the same format as that for class paths, but with a single entry.
+
+### Zip entry caches
+
+: This example shows 4 separate entries for zip entry caches:
+
+        1: 0x042FE07C ZIPCACHE: luni-kernel.jar_347075_1272300300_1 Address: 0x042FE094 Size: 7898
+        1: 0x042FA878 ZIPCACHE: luni.jar_598904_1272300546_1 Address: 0x042FA890 Size: 14195
+        1: 0x042F71F8 ZIPCACHE: nio.jar_405359_1272300546_1 Address: 0x042F7210 Size: 13808
+        1: 0x042F6D58 ZIPCACHE: annotation.jar_13417_1272300554_1 Address: 0x042F6D70 Size: 1023
+
+    - `1` : the ID of the VM that wrote this data.
+    - `0x042FE07C` : the address where the metadata for the zip entry cache is stored.
+    - `ZIPCACHE` : the type of data that was stored.
+    - `luni-kernel.jar_347075_1272300300_1` : the name of the zip entry cache.
+    - `0x042FE094` : the address where the data is stored.
+    - `7898` : the size of the stored data, in bytes.
+
+### JIT data
+: Information about JIT data is shown in `JITPROFILE` and `JITHINT` entries. For example:
+
+        1: 0xD6290368 JITPROFILE: getKeyHash Signature: ()I Address: 0xD55118C0
+        for ROMClass java/util/Hashtable$Entry at 0xD5511640.
+        2: 0xD6283848 JITHINT: loadClass Signature: (Ljava/lang/String;)Ljava/lang/Class; Address: 0xD5558F98
+        for ROMClass com/ibm/oti/vm/BootstrapClassLoader at 0xD5558AE0.
+
+## `printStats`
+
+```
+-Xshareclasses:printStats
+-Xshareclasses:printStats,name=<cache_name>
+-Xshareclasses:printStats=<data_type1>[+<data_type2>][...],name=<cache_name>
+```
+
+Displays summary information about the cache. For layered caches, this utility displays information about the cache in each layer (to see information for the top layer cache only, use [`printTopLayerStats`](#printtoplayerstats)). You can request more detail about items of a specific data type that are stored in the shared cache by using `printStats=<data_type>`. Use the plus symbol (+) to separate the data types. For example, use `printStats=romclass+url,name=myCache` to see information about `ROMClass` and `URL` items in all the layer caches of the cache called `myCache`. The valid data types are as follows (case insensitive):
+
+-   `help` (displays the list of valid data types)
+-   `all` (equivalent to `printAllStats`)
+-   `classpath`
+-   `url`
+-   `token`
+-   `romclass`
+-   `rommethod`
+-   `aot`
+-   `jitprofile`
+-   `jithint`
+-   `zipcache`
+-   `stale`
+-   `startuphint`
+
+Example output with summary information only:
+
+```
+Cache created with:
+        -Xnolinenumbers                      = false
+        BCI Enabled                          = true
+        Restrict Classpaths                  = true
+        Feature                              = cr
+
+Cache contains only classes with line numbers
+
+base address                         = 0x00007F44FC8EA000
+end address                          = 0x00007F44FD8CE000
+allocation pointer                   = 0x00007F44FCA1E650
+
+cache size                           = 16776608
+softmx bytes                         = 8388608
+free bytes                           = 5638158
+ROMClass bytes                       = 1263184
+AOT bytes                            = 20164
+Reserved space for AOT bytes         = -1
+Maximum space for AOT bytes          = -1
+JIT data bytes                       = 1120
+Reserved space for JIT data bytes    = -1
+Maximum space for JIT data bytes     = -1
+Zip cache bytes                      = 1149512
+Data bytes                           = 114080
+Metadata bytes                       = 22348
+Metadata % used                      = 0%
+Class debug area size                = 1331200
+Class debug area used bytes          = 179434
+Class debug area % used              = 13%
+
+# ROMClasses                         = 433
+# AOT Methods                        = 12
+# Classpaths                         = 1
+# URLs                               = 0
+# Tokens                             = 0
+# Zip caches                         = 21
+# Stale classes                      = 0
+% Stale classes                      = 0%
+
+Cache is 32% soft full
+
+Cache is accessible to current user = true
+```
+
+The `Cache created with` section indicates the options that were used when the cache was created. `BCI Enabled` relates to the `-Xshareclasses:enableBCI` option (enabled by default) and `Restrict Classpaths` relates to the `-Xshareclasses:restrictClasspaths` option. `Feature = cr` indicates that the cache is a 64-bit compressed references cache, as listed in [Creating, populating, monitoring, and deleting a cache](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_admin.html).
+
+Line number information for classes in the cache is then shown with one of the following messages:
+
+|Message|Explanation|
+|-------|-----------|
+|`Cache contains only classes with line numbers`|VM line number processing was enabled for all the classes that were stored in this shared cache (the `-Xlinenumbers` option is enabled by default). All classes in the cache contain line numbers if the original classes contained line number data.|
+|`Cache contains only classes without line numbers`|The `-Xnolinenumbers` option was used to disable VM line number processing for all the classes that were stored in this shared cache, so none of the classes contain line numbers.|
+|`Cache contains classes with line numbers and classes without line numbers`|VM line number processing was enabled for some classes and disabled for others (the `-Xnolinenumbers` option was specified when some of the classes were added to the cache).|
+
+The following summary data is displayed:
+
+#### `baseAddress` and `endAddress`
+ : The boundary addresses of the shared memory area that contains the classes.
+
+#### `allocPtr`
+ : The address where `ROMClass` data is currently being allocated in the cache.
+
+#### `cache size` and `free bytes`
+ : `cache size` shows the total size of the shared memory area in bytes, and `free bytes` shows the free bytes that remain.
+
+#### `softmx bytes`
+ : The soft maximum size for the cache. For more information, see [`-Xscmx`](xscmx.md).
+
+#### `ROMClass bytes`
+ : The number of bytes of class data in the cache.
+
+#### `AOT bytes`
+ : The number of bytes of AOT-compiled code in the cache.
+
+#### `Reserved space for AOT bytes`
+ : The number of bytes reserved for AOT-compiled code in the cache.
+
+#### `Maximum space for AOT bytes`
+ : The maximum number of bytes of AOT-compiled code that can be stored in the cache.
+
+#### `JIT data bytes`
+: The number of bytes of JIT-related data stored in the cache.
+
+#### `Reserved space for JIT data bytes`
+: The number of bytes reserved for JIT-related data in the cache.
+
+#### `Maximum space for JIT data bytes`
+: The maximum number of bytes of JIT-related data that can be stored in the cache.
+
+#### `Zip cache bytes`
+: The number of zip entry cache bytes stored in the cache.
+
+#### `Data bytes`
+: The number of bytes of non-class data stored by the VM.
+
+#### `Metadata bytes`
+: The number of bytes of data stored to describe the cached classes.
+
+#### `Metadata % used`
+: The proportion of metadata bytes to class bytes, which indicates how efficiently cache space is being used. The value shown does consider the `Class debug area size`.
+
+#### `Class debug area size`
+: The size in bytes of the Class Debug Area. This area is reserved to store `LineNumberTable` and `LocalVariableTable` class attribute information.
+
+#### `Class debug area bytes used`
+: The size in bytes of the Class Debug Area that contains data.
+
+#### `Class debug area % used`
+: The percentage of the Class Debug Area that contains data.
+
+#### `# ROMClasses`
+: The number of classes in the cache. The cache stores `ROMClasses` \(the class data itself, which is read-only\) and information about the location from which the classes were loaded. This information is stored in different ways, depending on the Java `SharedClassHelper` API that was used to store the classes. For more information, see [Using the Java Helper API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_helper.html).
+
+#### `# AOT methods`
+: Optionally, `ROMClass` methods can be compiled and the AOT code stored in the cache. The `# AOT methods` information shows the total number of methods in the cache that have AOT code compiled for them. This number includes AOT code for stale classes.
+
+#### `# Classpaths`, `URLs`, and `Tokens`
+: The number of class paths, URLs, and tokens in the cache. Classes stored from a `SharedClassURLClasspathHelper` are stored with a Classpath. Classes stored using a `SharedClassURLHelper` are stored with a URL. Classes stored using a `SharedClassTokenHelper` are stored with a Token. Most class loaders, including the bootstrap and application class loaders, use a `SharedClassURLClasspathHelper`. The result is that it is most common to see class paths in the cache.
+
+: The number of Classpaths, URLs, and Tokens stored is determined by a number of factors. For example, every time an element of a Classpath is updated, such as when a `.jar` file is rebuilt, a new Classpath is added to the cache. Additionally, if partitions or modification contexts are used, they are associated with the Classpath, URL, or Token. A Classpath, URL, or Token is stored for each unique combination of partition and modification context. For more information, see [SharedClassHelper partitions](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_rbm_partitions.html) and [Modification contexts](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_rbm_contexts.html).
+
+#### `# Zip caches`
+: The number of .zip files that have entry caches stored in the shared cache.
+
+#### `# Stale classes`
+: The number of classes that have been marked as "potentially stale" by the cache code, because of an operating system update. See [Understanding dynamic updates](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_dynamic.html).
+
+#### `% Stale classes`
+: The percentage of classes in the cache that are stale.
+
+#### `Cache is XXX% full`
+: The percentage of the cache that is currently used. This line is displayed only if the soft maximum size is not set. This value is calculated as follows:
+
+        % Full = (('Cache Size' - 'Free Bytes') * 100) / ('Cache Size')
+
+
+#### `Cache is XXX% soft full`
+: The percentage of the soft maximum size that is currently used. This line is displayed only if the soft maximum size is set. The `free bytes` in the cache statistics means the free bytes within the soft maximum limit. This value is calculated as follows:
+
+        % soft Full = (('Soft max bytes' - 'Free Bytes') * 100) / ('Soft max  bytes')
+
+For more information about the soft maximum size, see [`-Xscmx`](xscmx.md).
+
+#### `Cache is accessible to current user`
+: Whether the current user can access the cache.
+
+## `printTopLayerStats`
+
+Use this utility with a layered cache. This utility works in the same way as `printStats`, but shows information for the top layer cache only.

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -24,7 +24,7 @@
 
 # Shared classes cache diagnostic utilities
 
-These utilities display information about the contents of a shared classes cache. Run the utilities by specifying them as suboptions of `-Xshareclasses`. The utilities run on the default cache unless you specify a cache by adding the `name=<cache_name>` suboption. For layered caches, some information is shown for the top layer cache only, and some is shown for all layers combined. To see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats).
+These utilities display information about the contents of a shared classes cache. Run the utilities by specifying them as suboptions of `-Xshareclasses`. The utilities run on the default cache unless you specify a cache by adding the `name=<cache_name>` suboption.
 
 ## `printAllStats`
 
@@ -33,7 +33,7 @@ These utilities display information about the contents of a shared classes cache
 -Xshareclasses:printAllStats,name=<cache_name>
 ```
 
-Displays the contents of the cache in chronological order. You can use this output to see the history of updates that were made to the cache.
+Displays the contents of the cache in chronological order. You can use this output to see the history of updates that were made to the cache. For layered caches, some information is shown for the top layer cache only, and some is shown for all layers combined. To see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats).
 
 Each entry in the output starts with a VM ID, so you can see which VM wrote the associated data. Here are example entries for various types of cache data, with explanations:
 

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -24,7 +24,7 @@
 
 # Shared classes cache diagnostic utilities
 
-These utilities display information about the contents of a shared classes cache. Run the utilities by specifying them as suboptions of `-Xshareclasses`. The utilities run on the default cache unless you specify a cache by adding the `name=<cache_name>` suboption.
+These utilities display information about the contents of a shared classes cache. Run the utilities by specifying them as suboptions of `-Xshareclasses`. The utilities run on the default cache unless you specify a cache by adding the `name=<cache_name>` suboption. For layered caches, some information is shown for the top layer cache only, and some is shown for all layers combined. To see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats).
 
 ## `printAllStats`
 
@@ -266,10 +266,10 @@ The following summary data is displayed:
 
 : The number of Classpaths, URLs, and Tokens stored is determined by a number of factors. For example, every time an element of a Classpath is updated, such as when a `.jar` file is rebuilt, a new Classpath is added to the cache. Additionally, if partitions or modification contexts are used, they are associated with the Classpath, URL, or Token. A Classpath, URL, or Token is stored for each unique combination of partition and modification context. For more information, see [SharedClassHelper partitions](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_rbm_partitions.html) and [Modification contexts](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_rbm_contexts.html).
 
-#### `# Zip caches`
+#### `Zip caches`
 : The number of .zip files that have entry caches stored in the shared cache.
 
-#### `# Stale classes`
+#### `Stale classes`
 : The number of classes that have been marked as "potentially stale" by the cache code, because of an operating system update. See [Understanding dynamic updates](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_dynamic.html).
 
 #### `% Stale classes`

--- a/docs/version0.17.md
+++ b/docs/version0.17.md
@@ -52,11 +52,16 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 **(Experimental, 64-bit only)**
 
-Two new suboptions, `createLayer` and `layer=<number>`, are available for creating layered caches, where a cache builds on another cache with the same name. You can use these suboptions to save space when building a Docker container, for example. For more information, see [`-Xshareclasses:layer`](xshareclasses.md#layer).
-
-A new suboption, [`destroyAllLayers`](xshareclasses.md#destroyalllayers), is available for destroying all the layers of a layered cache.
+New suboptions are available for creating layered caches, where a cache builds on another cache with the same name. You can use these suboptions to save space when building a Docker container, for example.
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Because these suboptions are experimental, do not use them in a production environment.
+
+The new options are:
+
+- [`createLayer`](xshareclasses.md#createlayer)
+- [`layer=<number>`](xshareclasses.md#layer) (see this section for more information about layered caches)
+- [`printTopLayerStats`](xshareclasses.md#printtoplayerstats-cache-utility)
+- [`destroyAllLayers`](xshareclasses.md#destroyalllayers)
 
 ### New shared classes cache suboption to skip disk space check
 

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -348,6 +348,8 @@ case, the VM continues without using shared classes.
 
 : When you use the `-Xshareclasses:name=Cache1` suboption in future Java commands, all the caches are started. The top-layer cache is started in read/write mode, and lower-layer caches are started in read-only mode. Modifying a lower-layer cache would invalidate all the caches in the layers above.
 
+: <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** The [`jvmtiSharedCacheInfo.isCorrupt`](interface_jvmti.md#jvmtisharedcacheinfo-structure) field and the  [`SharedClassCacheInfo.isCacheCorrupt()`](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.oti.shared/com/ibm/oti/shared/SharedClassCacheInfo.html#isCacheCorrupt--) method cannot detect a corrupted cache that has a layer number other than `0`. However, when a VM starts a layered cache directly, for example when you specify the `-Xshareclasses:name=<cache_name>` option on the command line, the VM detects any corruption and generates an error message as usual, regardless of the layer number of the cache.
+
 ### `listAllCaches` (Cache utility)
 
         -Xshareclasses:listAllCaches
@@ -466,17 +468,23 @@ behavior, which can improve the performance of class loading from the shared cla
 
         -Xshareclasses:printAllStats
 
-:   Displays detailed information about the contents of the cache that is specified in the [`name`](#name) suboption. If the name is not specified, statistics are displayed about the default cache. Every class is listed in chronological order with a reference to the location from which it was loaded. For more information, see [printAllStats utility](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_out_printallstats.html).
+:   Displays detailed information about the contents of the cache that is specified in the [`name`](#name) suboption. If the name is not specified, statistics are displayed about the default cache. For layered caches, information is shown for the cache in each layer (to see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats-cache-utility)). Every class is listed in chronological order with a reference to the location from which it was loaded. For more information, see [Diagnostic cache utilities](shrc_diag_util.md).
 
 ### `printStats` (Cache utility)
 
         -Xshareclasses:printStats=<data_type>[+<data_type>]
 
-:   Displays summary information for the cache that is specified by the [`name`](#name), [`cacheDir`](#cachedir), and [`nonpersistent`](#nonpersistent) suboptions. The most useful information that is displayed is how full the cache is and how many classes it contains. Stale classes are classes that are updated on the file system and which the cache has therefore marked as "stale". Stale classes are not purged from the cache and can be reused. Use the `printStats=stale` option to list all the stale entries and stale bytes.
+:   Displays summary information for the cache that is specified by the [`name`](#name), [`cacheDir`](#cachedir), and [`nonpersistent`](#nonpersistent) suboptions. For layered caches, information is shown for the cache in each layer (to see information for the top layer cache only, use [`printTopLayerStats`](#printtoplayerstats-cache-utility)). The most useful information that is displayed is how full the cache is and how many classes it contains. Stale classes are classes that are updated on the file system and which the cache has therefore marked as "stale". Stale classes are not purged from the cache and can be reused. Use the `printStats=stale` option to list all the stale entries and stale bytes.
 
 : Specify one or more data types, which are separated by a plus symbol (+), to see more detailed information about the cache content. Data types include AOT data, class paths, and ROMMethods.
 
-: For more information and for a full list of data types, see [printStats utility](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_out_printstats.html).
+: For more information and for a full list of data types, see [Diagnostic cache utilities](shrc_diag_util.md).
+
+### `printTopLayerStats` (Cache utility)
+
+        -Xshareclasses:printTopLayerStats=<data_type>[+<data_type>]
+
+:   Equivalent to [`printStats`](#printstats-cache-utility) but for the top layer cache only.
 
 ### `readonly`
 

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -468,13 +468,13 @@ behavior, which can improve the performance of class loading from the shared cla
 
         -Xshareclasses:printAllStats
 
-:   Displays detailed information about the contents of the cache that is specified in the [`name`](#name) suboption. If the name is not specified, statistics are displayed about the default cache. For layered caches, information is shown for the cache in each layer (to see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats-cache-utility)). Every class is listed in chronological order with a reference to the location from which it was loaded. For more information, see [Diagnostic cache utilities](shrc_diag_util.md).
+:   Displays detailed information about the contents of the cache that is specified in the [`name`](#name) suboption. If the name is not specified, statistics are displayed about the default cache. For layered caches, information is shown for all layers (to see information for the top layer cache only, use [`printTopLayerStats=all`](#printtoplayerstats-cache-utility)). Every class is listed in chronological order with a reference to the location from which it was loaded. For more information, see [Diagnostic cache utilities](shrc_diag_util.md).
 
 ### `printStats` (Cache utility)
 
         -Xshareclasses:printStats=<data_type>[+<data_type>]
 
-:   Displays summary information for the cache that is specified by the [`name`](#name), [`cacheDir`](#cachedir), and [`nonpersistent`](#nonpersistent) suboptions. For layered caches, information is shown for the cache in each layer (to see information for the top layer cache only, use [`printTopLayerStats`](#printtoplayerstats-cache-utility)). The most useful information that is displayed is how full the cache is and how many classes it contains. Stale classes are classes that are updated on the file system and which the cache has therefore marked as "stale". Stale classes are not purged from the cache and can be reused. Use the `printStats=stale` option to list all the stale entries and stale bytes.
+:   Displays summary information for the cache that is specified by the [`name`](#name), [`cacheDir`](#cachedir), and [`nonpersistent`](#nonpersistent) suboptions. For layered caches, information is shown for all layers (to see information for the top layer cache only, use [`printTopLayerStats`](#printtoplayerstats-cache-utility)). The most useful information that is displayed is how full the cache is and how many classes it contains. Stale classes are classes that are updated on the file system and which the cache has therefore marked as "stale". Stale classes are not purged from the cache and can be reused. Use the `printStats=stale` option to list all the stale entries and stale bytes.
 
 : Specify one or more data types, which are separated by a plus symbol (+), to see more detailed information about the cache content. Data types include AOT data, class paths, and ROMMethods.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,7 +120,9 @@ pages:
 
     - "AOT Compiler"                                                             : aot.md
 
-    - "Class data sharing"                                                       : shrc.md
+    - "Class data sharing" :
+        - "Overview"                                                             : shrc.md
+        - "Diagnostic cache utilities"                                           : shrc_diag_util.md
 
     - "Diagnostics" :
 


### PR DESCRIPTION
Add restriction and printTopLayerStats. Move printStats and printAllStats from IBM KC doc to OpenJ9.

https://github.com/eclipse/openj9-docs/issues/368

Signed-off-by: Esther Dovey doveye@uk.ibm.com

[skip ci]