### PR TITLE
LUDCL caching now disabled by default.

### DIFF
--- a/docs/version0.17.md
+++ b/docs/version0.17.md
@@ -36,6 +36,7 @@ The following new features and notable changes since v.0.16 are included in this
 - [Digest algorithm is re-enabled](#digest-algorithm-is-re-enabled)
 - [Direct Dump Reader (DDR) VM restriction removed](#direct-dump-reader-ddr-vm-restriction-removed)
 - [The format of the HOOKS section of a Java dump has changed](#the-format-of-the-hooks-section-of-a-java-dump-has-changed)
+- [LUDCL caching disabled by default](#ludcl-caching-disabled-by-default)
 
 ## Features and changes
 
@@ -92,9 +93,14 @@ The format of the `HOOKS` section of a Java dump, which shows internal VM event 
 
 - Recorded times have been changed from milliseconds to microseconds to provide increased precision.
 - A new field, `3HKTOTALTIME`, is included, which gives the total duration of previous events.
-- The hook data is now reset after after each Java dump.
+- The hook data is now reset after each Java dump.
 
 For more information and an example of the new format, see [Java dump: HOOKS](dump_javadump.md#hooks)
+
+### LUDCL caching disabled by default
+
+By caching the Latest User Defined Class Loader (LUDCL), Java applications that use deserialization extensively can see a performance improvement. This
+capability is controlled by the [-Dcom.ibm.enableClassCaching](dcomibmenableclasscashing.md) system property and is now disabled by default. Versions of the documentation before 0.17.0 incorrectly identified this property as disabled by default when it was actually enabled by default in the VM.
 
 ## Full release information
 


### PR DESCRIPTION
Added content to release notes. Docs incorrectly stated that this
was disabled by default already, when OpenJ9 used to enable by default.

Closes: #386

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>