### PR TITLE
Tidy release notes

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -43,16 +43,16 @@ columns will be removed over time.
 
 ## Eclipse OpenJ9 releases
 
-| OpenJ9 release  | Release date        | JDK8 (LTS)| JDK11 (LTS) | JDK13     | JDK14     |
-|-----------------|---------------------|-----------|-------------|-----------|-----------|
-| v0.12.0         | January 2019        | Yes       | Yes         |           |           |
-| v0.13.0         | March 2019          | No        | No          |           |           |
-| v0.14.0         | April 2019          | Yes       | Yes         |           |           |
-| v0.15.0         | July 2019           | Yes       | Yes         |           |           |
-| v0.16.0         | September 2019      | No        | No          | Yes (\*2) |           |
-| v0.17.0         | October 2019        | Yes       | Yes         | Yes       |           |
-| v0.18.0         | January 2020 (\*1)  | Yes       | Yes         | Yes       |           |
-| v0.19.0         | March 2020 (\*1)    | No        | No          | No        | Yes (\*2) |
+| OpenJ9 release   | Release date        | JDK8 (LTS)| JDK11 (LTS) | JDK13     | JDK14     |
+|------------------|---------------------|-----------|-------------|-----------|-----------|
+| v 0.12.0         | January 2019        | Yes       | Yes         |           |           |
+| v 0.13.0         | March 2019          | No        | No          |           |           |
+| v 0.14.0         | April 2019          | Yes       | Yes         |           |           |
+| v 0.15.0         | July 2019           | Yes       | Yes         |           |           |
+| v 0.16.0         | September 2019      | No        | No          | Yes (\*2) |           |
+| v 0.17.0         | October 2019        | Yes       | Yes         | Yes       |           |
+| v 0.18.0         | January 2020 (\*1)  | Yes       | Yes         | Yes       |           |
+| v 0.19.0         | March 2020 (\*1)    | No        | No          | No        | Yes (\*2) |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
 

--- a/docs/version0.10.md
+++ b/docs/version0.10.md
@@ -64,5 +64,6 @@ For compatibility, the following OpenJDK Hotspot options are now supported by Op
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.9.0 and V0.10.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.10/0.10.md).
-<!-- ==== END OF TOPIC ==== cmdline_general.md ==== -->
+To see a complete list of changes between Eclipse OpenJ9 v 0.9.0 and v 0.10.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.10/0.10.md).
+
+<!-- ==== END OF TOPIC ==== version0.10.md ==== -->

--- a/docs/version0.11.md
+++ b/docs/version0.11.md
@@ -25,7 +25,7 @@
 
 # What's new in version 0.11.0
 
-The following new features and notable changes since v.0.10.0 are included in this release:
+The following new features and notable changes since v 0.10.0 are included in this release:
 
 - [New binaries and changes to supported environments.](#binaries-and-supported-environments)
 - ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) [OpenSSL is now supported for improved native cryptographic performance](#openssl-is-now-supported-for-improved-native-cryptographic-performance)
@@ -117,5 +117,6 @@ For compatibility, the following OpenJDK Hotspot options are now supported by Op
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.10.0 and V0.11.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.11/0.11.md).
-<!-- ==== END OF TOPIC ==== cmdline_general.md ==== -->
+To see a complete list of changes between Eclipse OpenJ9 v 0.10.0 and v 0.11.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.11/0.11.md).
+
+<!-- ==== END OF TOPIC ==== version0.11.md ==== -->

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -27,7 +27,7 @@
 
 ## Version 0.12.0
 
-The following new features and notable changes since V0.11.0 are included in this release:
+The following new features and notable changes since v 0.11.0 are included in this release:
 
 - [Improved flexibility for managing the size of the JIT code cache](#improved-flexibility-for-managing-the-size-of-the-jit-code-cache)
 <!-- - [Class data sharing is enabled by default](#class-data-sharing-is-enabled-by-default) -->
@@ -87,7 +87,7 @@ For more information, see [`-Xshareclasses`](xshareclasses.md#cachedirperm).
 
 OpenSSL is a native open source cryptographic toolkit for Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols, which provides improved cryptographic performance compared to the in-built OpenJDK Java cryptographic implementation. The OpenSSL V1.1.x implementation is enabled by default and  supported for the Digest, CBC, and GCM algorithms. Binaries obtained from AdoptOpenJDK include OpenSSL v1.1.x (see Note). For more information about tuning the OpenSSL implementation, see [Performance tuning](introduction.md#cryptographic-operations).
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** OpenJDK 8 with OpenJ9 includes OpenSSL support since V0.11.0. Currently, OpenSSL is not bundled as part of the AdoptOpenJDK AIX binaries due to an unresolved problem.
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** OpenJDK 8 with OpenJ9 includes OpenSSL support since v 0.11.0. Currently, OpenSSL is not bundled as part of the AdoptOpenJDK AIX binaries due to an unresolved problem.
 
 ![End of content that applies only to Java 11 (LTS)](cr/java_close_lts.png)
 
@@ -96,7 +96,7 @@ OpenSSL is a native open source cryptographic toolkit for Transport Layer Securi
 
 Concurrent scavenge mode is now supported on 64-bit Windows operating systems.
 
-In Eclipse OpenJ9 V0.11.0, support was added for `-Xgc:concurrentScavenge` on Linux x86-64 virtual machines that use compressed references. In this release, support is now available for Linux x86-64 large-heap virtual machines (non-compressed references).
+In Eclipse OpenJ9 v 0.11.0, support was added for `-Xgc:concurrentScavenge` on Linux x86-64 virtual machines that use compressed references. In this release, support is now available for Linux x86-64 large-heap virtual machines (non-compressed references).
 
 For more information, see the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge) option.
 
@@ -110,17 +110,17 @@ The VM environment variable `IBM_JAVA_OPTIONS` is deprecated and is replaced by 
 
 ### Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.11.0 and V0.12.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.12/0.12.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.11.0 and v 0.12.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.12/0.12.md).
 
 ## Version 0.12.1
 
-The following change is implemented since V0.12.0:
+The following change is implemented since v 0.12.0:
 
-By default, OpenJ9 provides native cryptographic acceleration using OpenSSL V1.1.x for the Digest, CBC, GCM, and RSA algorithms. Under certain circumstances acceleration of the Digest algorithm was found to cause a segmentation error. Cryptographic acceleration of the Digest algorithm is now turned off by default. The system property `-Djdk.nativeDigest` cannot be used to turn on support. This property is ignored by the VM.
+By default, OpenJ9 provides native cryptographic acceleration using OpenSSL v 1.1.x for the Digest, CBC, GCM, and RSA algorithms. Under certain circumstances acceleration of the Digest algorithm was found to cause a segmentation error. Cryptographic acceleration of the Digest algorithm is now turned off by default. The system property `-Djdk.nativeDigest` cannot be used to turn on support. This property is ignored by the VM.
 
 ### Full release information
 
-Release notes to describe the changes between Eclipse OpenJ9 V0.12.0 and V0.12.1 releases, can be found in the [OpenJ9 GitHub repository](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.12/0.12.1.md).
+Release notes to describe the changes between Eclipse OpenJ9 v 0.12.0 and v 0.12.1 releases, can be found in the [OpenJ9 GitHub repository](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.12/0.12.1.md).
 
 
 

--- a/docs/version0.13.md
+++ b/docs/version0.13.md
@@ -25,7 +25,7 @@
 
 # What's new in version 0.13.0
 
-The following new features and notable changes since v.0.12.1 are included in this release:
+The following new features and notable changes since v 0.12.1 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies only to Java 12](cr/java12.png) [Support for OpenSSL 1.0.2](#support-for-openssl-102)
@@ -87,6 +87,6 @@ For more information, see the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscave
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.12.1 and V0.13.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.13/0.13.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.12.1 and v 0.13.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.13/0.13.md).
 
 <!-- ==== END OF TOPIC ==== version0.13.md ==== -->

--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -27,7 +27,7 @@
 
 ## Version 0.14.0
 
-The following new features and notable changes since V0.13.0 are included in this release:
+The following new features and notable changes since v 0.13.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Support for OpenSSL 1.0.2](#support-for-openssl-102)
@@ -96,11 +96,11 @@ The default stack size for operating system threads on 64-bit z/OS is changed fr
 
 ### Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.13.0 and V0.14.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.14/0.14.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.13.0 and v 0.14.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.14/0.14.md).
 
 ## Version 0.14.2
 
-The following new features and notable changes since V0.14.0 are included in this release:
+The following new features and notable changes since v 0.14.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Support for OpenSSL 1.0.1](#support-for-openssl-101)

--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -25,7 +25,7 @@
 
 # What's new in version 0.15.1
 
- The following new features and notable changes since v.0.14.0 are included in this release:
+ The following new features and notable changes since v 0.14.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Performance improvements for JVMTI watched fields](#performance-improvements-for-jvmti-watched-fields)
@@ -123,6 +123,6 @@ In earlier releases, the shared classes cache checks timestamps of `jar` or `zip
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.14.0 and V0.15.1 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.15/0.15.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.14.0 and v 0.15.1 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.15/0.15.md).
 
 <!-- ==== END OF TOPIC ==== version0.15.md ==== -->

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -23,9 +23,9 @@
 -->
 
 
-# What's new in version 0.16
+# What's new in version 0.16.0
 
-The following new features and notable changes since v.0.15.1 are included in this release:
+The following new features and notable changes since v 0.15.1 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Some class data sharing is enabled by default](#some-class-data-sharing-is-enabled-by-default)
@@ -87,6 +87,6 @@ The option [`-Xverify:none`](xverify.md) (and its equivalent `-noverify`) is dep
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.15.1 and V0.16.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.16/0.16.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.15.1 and v 0.16.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.16/0.16.md).
 
 <!-- ==== END OF TOPIC ==== version0.15.md ==== -->

--- a/docs/version0.17.md
+++ b/docs/version0.17.md
@@ -23,9 +23,9 @@
 -->
 
 
-# What's new in version 0.17
+# What's new in version 0.17.0
 
-The following new features and notable changes since v.0.16 are included in this release:
+The following new features and notable changes since v 0.16.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [New shared classes cache suboptions for layered caches](#new-shared-classes-cache-suboptions-for-layered-caches)
@@ -105,12 +105,12 @@ For more information and an example of the new format, see [Java dump: HOOKS](du
 ### LUDCL caching disabled by default
 
 By caching the Latest User Defined Class Loader (LUDCL), Java applications that use deserialization extensively can see a performance improvement. This
-capability is controlled by the [-Dcom.ibm.enableClassCaching](dcomibmenableclasscashing.md) system property and is now disabled by default due to [issue #7332](https://github.com/eclipse/openj9/issues/7332).
+capability is controlled by the [-Dcom.ibm.enableClassCaching](dcomibmenableclasscaching.md) system property and is now disabled by default due to [issue #7332](https://github.com/eclipse/openj9/issues/7332).
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Versions of the documentation before 0.17.0 incorrectly identified this property as disabled by default when it was actually enabled by default in the VM.
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.16 and V0.17.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.17/0.17.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.16 and v 0.17.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.17/0.17.md).
 
 <!-- ==== END OF TOPIC ==== version0.17.md ==== -->

--- a/docs/version0.9.md
+++ b/docs/version0.9.md
@@ -52,8 +52,8 @@ Complete platform support information for OpenJ9 can be found in [Supported envi
 ### Idle tuning feature
 
 The idle tuning feature in OpenJ9 keeps your memory footprint small by releasing unused memory back to the
-operating system. Prior to Eclipse v0.9.0 this feature was available only on Linux x86 architectures with the
-`gencon` garbage collection policy. From v0.9.0, this feature is now available on Linux for IBM POWER&reg; and IBM Z&reg; architectures.
+operating system. Prior to Eclipse v 0.9.0 this feature was available only on Linux x86 architectures with the
+`gencon` garbage collection policy. From v 0.9.0, this feature is now available on Linux for IBM POWER&reg; and IBM Z&reg; architectures.
 For more information about this feature, see the following command line options, which control this
 behavior:
 
@@ -137,5 +137,5 @@ For performance and compatibility with the new String object layout, the OpenJ9 
 
 ## Full release information
 
-To see a complete list of changes between Eclipse OpenJ9 V0.8.0 and V0.9.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.9/0.9.md).
+To see a complete list of changes between Eclipse OpenJ9 v 0.8.0 and v 0.9.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.9/0.9.md).
 <!-- ==== END OF TOPIC ==== cmdline_general.md ==== -->


### PR DESCRIPTION
- make "v" before versions consistent
- fix broken link in 0.17.0

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>