### PR TITLE
Update jextract on macOS

### DIFF
--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -42,7 +42,7 @@ The dump viewer is useful for diagnosing `OutOfMemoryError` exceptions in Java&t
 |          Input option   |  Explanation                                                                                           |
 |-------------------------|--------------------------------------------------------------------------------------------------------|
 | `-core <core file>`     | Specifies a dump file.                                                                                 |
-| `-zip <zip file>`       | Specifies a compressed file containing the core file and associated XML file (produced by the [dump extractor (`jextract`)](tool_jextract.md) tool on AIX&reg; and Linux&trade; systems). |
+| `-zip <zip file>`       | Specifies a compressed file containing the core file and associated XML file (produced by the [dump extractor (`jextract`)](tool_jextract.md) tool on AIX&reg;, Linux&trade;, and macOS&reg; systems). |
 | `-notemp`               | By default, when you specify a file by using the `-zip` option, the contents are extracted to a temporary directory before processing. Use the `-notemp` option to prevent this extraction step, and run all subsequent commands in memory. |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The `-core` option can be used with the `-zip` option to specify the core and XML files in the compressed file. Without these options, `jdmpview` shows multiple contexts, one for each source file that it identified in the compressed file.  

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -24,7 +24,7 @@
 
 # Dump extractor (`jextract`)
 
-**(AIX&reg;, Linux&trade;, ![Start of content that applies only to Java 11 (LTS) and later](cr/java11plus.png) macOS&reg;![End of content that applies only to Java 10 and later](cr/java_close_lts.png))**
+**(AIX&reg;, Linux&trade;, macOS&reg;)**
 
 On some operating systems, copies of executable files and libraries are required for a full analysis of a core dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these extra files and package them into an archive file along with the core dump. To analyze the output, use the [dump viewer (`jdmpview`)](tool_jdmpview.md).
 

--- a/docs/version0.18.md
+++ b/docs/version0.18.md
@@ -1,0 +1,47 @@
+<!--
+* Copyright (c) 2017, 2019 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# What's new in version 0.18.0
+
+The following new features and notable changes since v 0.17.0 are included in this release:
+
+- [jextract now available on macOS for OpenJDK version 8](#jextract-now-available-on-macos-for-openjdk-version-8)
+- [Add more changes here...](#add-more-changes-here)
+
+
+## Features and changes
+
+### jextract now available on macOS for OpenJDK version 8
+
+The [`jextract` tool](tool_jextract.md) is now available on macOS&reg; platforms (as well as AIX&reg; and Linux&trade;) for _all_ current versions of OpenJDK: 8, 11, and 13.
+
+### Add more changes here...
+
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 v 0.17.0 and v 0.18.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.18/0.18.md).
+
+<!-- ==== END OF TOPIC ==== version0.18.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,11 +102,12 @@ pages:
     - "New to OpenJ9?"                                                           : openj9_newuser.md
 
     - "Release notes" :
+        - "Version 0.18.0"                                                       : version0.18.md
         - "Version 0.17.0"                                                       : version0.17.md
         - "Version 0.16.0"                                                       : version0.16.md
         - "Version 0.15.1"                                                       : version0.15.md
-        - "Version 0.14.0"                                                       : version0.14.md
         - "Earlier releases" :
+            - "Version 0.14.0"                                                   : version0.14.md
             - "Version 0.13.0"                                                   : version0.13.md
             - "Version 0.12.0"                                                   : version0.12.md
             - "Version 0.11.0"                                                   : version0.11.md


### PR DESCRIPTION
Indicate that jextract is now available fopr all current
versions of OpenJDK running on macOS.

Update jextract and jdmpview topics, and add to a new version0.18 topic.

Closes #268

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>