### PR TITLE
Concurrent scavenge mode extended to macOS

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -106,7 +106,7 @@ A special mode of the `gencon` policy is known as *Concurrent Scavenge* (`-Xgc:c
     - [Reducing Garbage Collection pause times with Concurrent Scavenge and the Guarded Storage Facility](https://developer.ibm.com/javasdk/2017/09/18/reducing-garbage-collection-pause-times-concurrent-scavenge-guarded-storage-facility/)
     - [How Concurrent Scavenge using the Guarded Storage Facility Works](https://developer.ibm.com/javasdk/2017/09/25/concurrent-scavenge-using-guarded-storage-facility-works/)
 
-- **Software-based support: (64-bit: Linux on (x86-64, POWER, IBM Z&reg;), AIX&reg;, and z/OS&reg;)** With software-based support, *Concurrent Scavenge* can be enabled without any pre-requisite hardware although the performance throughput is not as good as hardware-based support.
+- **Software-based support: (64-bit: Linux on (x86-64, POWER, IBM Z&reg;), AIX&reg;, macOS&reg;, and z/OS&reg;)** With software-based support, *Concurrent Scavenge* can be enabled without any pre-requisite hardware although the performance throughput is not as good as hardware-based support.
 
 For more information about enabling Concurrent Scavenge, see the [-Xgc:concurrentScavenge](xgc.md#concurrentscavenge) option.
 

--- a/docs/version0.18.md
+++ b/docs/version0.18.md
@@ -33,6 +33,7 @@ The following new features and notable changes since v 0.17.0 are included in th
 - [-XX:+TransparentHugePage is enabled by default on more Linux systems](#xxtransparenthugepage-is-enabled-by-default-on-more-linux-systems)
 - [Add new Xdump exit agent and ExitOnOutOfMemoryError option](#add-new-xdump-exit-agent-and-exitonoutofmemoryerror-option)
 - [LUDCL caching enabled by default](#ludcl-caching-enabled-by-default)
+- [Improved support for pause-less garbage collection](#improved-support-for-pause-less-garbage-collection)
 - [Add more changes here...](#add-more-changes-here)
 
 
@@ -65,6 +66,10 @@ The Xdump "exit" agent is used in the implementation of `-XX:[+-]ExitOnOutOfMemo
 ### LUDCL caching enabled by default
 By caching the Latest User Defined Class Loader (LUDCL), Java applications that use deserialization extensively can see a performance improvement. This
 capability is controlled by the [-Dcom.ibm.enableClassCaching](dcomibmenableclasscaching.md) system property and is now enabled by default. This feature was disabled for the 0.17.0 release due to [issue #7332](https://github.com/eclipse/openj9/issues/7332) which has now been resolved.
+
+#### Improved support for pause-less garbage collection
+
+Support for Concurrent scavenge mode is now extended to macOS&reg;. For more information, see [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge).
 
 ### Add more changes here...
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -52,7 +52,7 @@ Options that change the behavior of the Garbage Collector (GC).
 
 ### `concurrentScavenge`
 
-**(64-bit: Windows, AIX, Linux (x86, POWER&reg;, or IBM Z&reg;), and z/OS&reg;)**
+**(64-bit: Windows, AIX, Linux (x86, POWER&reg;, or IBM Z&reg;), macOS&reg;, and z/OS&reg;)**
 
         -Xgc:concurrentScavenge
 


### PR DESCRIPTION
Concurrent scavenge mode supported platforms must be updated to include macOS.

Following docs updated:
- Release notes v0.18
- GC platform list
- xgc options

Closes https://github.com/eclipse/openj9-docs/issues/433

Signed-off-by: Salman Rana <salman.rana@ibm.com>