### PR TITLE
Correct documentation regarding XcompilationThreads option

### DIFF
--- a/docs/xcompilationthreads.md
+++ b/docs/xcompilationthreads.md
@@ -31,7 +31,7 @@ Use this option to specify the number of compilation threads that are used by th
 
         -XcompilationThreads<n>
 
-: where `<n>` is the number of threads, in the range 1-4 inclusive. A number greater than 4 prevents the Java&trade; VM from starting successfully. 
+: where `<n>` is the number of threads, in the range 1-7 inclusive. Any number outside this range is ignored. 
 
 : Setting the compilation threads to zero does not prevent the JIT from working. Instead, if you do not want the JIT to work, use the [`-Xint`](xint.md) option.
 


### PR DESCRIPTION
Existing documentation specifies that the number of compilation threads
needs to be in the 1-4 interval. Starting with Java8 we have increased the
maximum number of compilation threads to 7.
Also, the behavior has changed in that the JVM will no longer fail if the
user specifies an invalid number of compilation threads; instead it will use
the default number according to its internal heuristics.

Closes #435

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>