### PR TITLE
Ad hoc fixes for 0.18.0

### DIFF
--- a/docs/env_var.md
+++ b/docs/env_var.md
@@ -103,17 +103,14 @@ Where:
 
 `JAVA_DUMP_OPTS` is parsed by taking the leftmost occurrence of each condition, so duplicates are ignored. The following setting produces a system dump for the first error condition only:
 
-    :::java
     ONERROR(SYSDUMP[1]),ONERROR(JAVADUMP)
 
 Also, the `ONANYSIGNAL` condition is parsed before all others, so
 
-    :::java
     ONINTERRUPT(NONE),ONANYSIGNAL(SYSDUMP)
 
 has the same effect as
 
-    :::java
     ONANYSIGNAL(SYSDUMP),ONINTERRUPT(NONE)
 
 
@@ -158,15 +155,15 @@ The preferred mechanism for controlling the production of Java dumps is by using
 
 The preferred mechanism for controlling the production of Java dumps is by using the `-Xdump:heap` option. However, these legacy environment variables are preserved and can still be used.
 
-| Environment Variable           | Usage Information                                                                                                          |
-|--------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-|`IBM_HEAPDUMP=[TRUE|FALSE]`     | Setting this option to `TRUE` enables heap dump production by using signals.                                               |
-|`IBM_HEAP_DUMP=[TRUE|FALSE]`    |  Setting this option to `TRUE` enables heap dump production by using signals.                                               |
-|`IBM_HEAPDUMPDIR=<directory>`   | The default location into which the heap dump is written. On z/OS, the `_CEE_DMPTARG` environment variable is used instead.                             |
+| Environment Variable                  | Usage Information                                                                                                          |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+|`IBM_HEAPDUMP=[TRUE|FALSE]`            | Setting this option to `TRUE` enables heap dump production by using signals.                                               |
+|`IBM_HEAP_DUMP=[TRUE|FALSE]`           |  Setting this option to `TRUE` enables heap dump production by using signals.                                               |
+|`IBM_HEAPDUMPDIR=<directory>`          | The default location into which the heap dump is written. On z/OS, the `_CEE_DMPTARG` environment variable is used instead.                             |
 |`IBM_HEAPDUMP_OUTOFMEMORY=[TRUE|FALSE]`| Controls the generation of a heap dump when an out-of-memory exception is thrown. When not set, a heap dump is generated when an out-of-memory exception is thrown but not caught and handled by the application. Set to TRUE to generate a dump when an out-of-memory exception is thrown, even if it is handled by the application. Set to FALSE to disable heap dump for an out-of-memory exception.                                                   |
-|`IBM_JAVA_HEAPDUMP_TEST`        | Use this environment variable to cause the VM to generate both PHD and text versions of heap dumps. Equivalent to `opts=PHD+CLASSIC` on the `-Xdump:heap` option.|
-|`IBM_JAVA_HEAPDUMP_TEXT`        | Use this environment variable to cause the VM to generate a text (human readable) Heap dump. Equivalent to `opts=CLASSIC` on the `-Xdump:heap` option.|
-|`TMPDIR=<directory>`            | This variable specifies an alternative temporary directory. This directory is used only when Java dumps and heap dumps cannot be written to their target directories, or the current working directory. The default is `/tmp` (`C:\temp` for Windows).|
+|`IBM_JAVA_HEAPDUMP_TEST`               | Use this environment variable to cause the VM to generate both PHD and text versions of heap dumps. Equivalent to `opts=PHD+CLASSIC` on the `-Xdump:heap` option.|
+|`IBM_JAVA_HEAPDUMP_TEXT`               | Use this environment variable to cause the VM to generate a text (human readable) Heap dump. Equivalent to `opts=CLASSIC` on the `-Xdump:heap` option.|
+|`TMPDIR=<directory>`                   | This variable specifies an alternative temporary directory. This directory is used only when Java dumps and heap dumps cannot be written to their target directories, or the current working directory. The default is `/tmp` (`C:\temp` for Windows).|
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** You can use the dump agent `JAVA_DUMP_OPTS` variable to control the conditions under which Heap dumps are produced.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -106,7 +106,7 @@ To build a version of OpenJDK with OpenJ9 that includes OpenSSL support, follow 
 
 OpenJ9 provides the [CUDA4J API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.cuda/index.html?view=kc) and the [com.ibm.gpu API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.gpu/index.html?view=kc), which allow you to develop applications that can take advantage of graphics processing unit (GPU) processing for suitable functions, such as code page conversion. You can also enable the JIT compiler to offload certain processing tasks to a GPU by specifying the `-Xjit:enableGPU` option on the command line. When enabled, the JIT compiler determines when to offload tasks based on performance heuristics.
 
-GPU processing is supported only on Windows (x86-64) and Linux (x86-64 and IBM Power LE) systems. For more information about enabling GPU processing, see [Exploiting graphics processing units](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.80.doc/docs/gpu_overview.html).
+GPU processing is supported only on Windows (x86-64) and Linux (x86-64 and IBM Power LE) systems. For more information about enabling GPU processing, see [Exploiting graphics processing units](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/gpu_overview.html).
 
 ## Runtime options
 
@@ -128,4 +128,4 @@ The OpenJ9 diagnostic component contains extensive features to assist with probl
 To get started, read [Diagnostic tools and data](diag_overview.md).
 
 
-<!-- ==== END OF TOPIC ==== index.md ==== -->
+<!-- ==== END OF TOPIC ==== introduction.md ==== -->

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -131,16 +131,18 @@ The information section is followed by a sequence of lines that describe the met
 
 Here is a typical line from the verbose log:
 
-`+ (cold) sun/reflect/Reflection.getCallerClass()Ljava/lang/Class; @ 00007FCACED1303C-00007FCACED13182 OrdinaryMethod - Q_SZ=0 Q_SZI=0 QW=1 j9m=00000000011E7EA8 bcsz=2 JNI compThread=0 CpuLoad=2%(2%avg) JvmCpu=0%`
+```
++ (cold) sun/reflect/Reflection.getCallerClass()Ljava/lang/Class; @ 00007FCACED1303C-00007FCACED13182 OrdinaryMethod - Q_SZ=0 Q_SZI=0 QW=1 j9m=00000000011E7EA8 bcsz=2 JNI compThread=0 CpuLoad=2%(2%avg) JvmCpu=0%
+```
 
 In this example:
 
-- The method compiled is sun/reflect/Reflection.getCallerClass()Ljava/lang/Class.
-- The + indicates that this method is successfully compiled. Failed compilations are marked by a !.
-- (cold) tells you the optimization level that was applied. Other examples may be (warm) or (scorching).
-- 00007FCACED1303C-00007FCACED13182 is the code range where the compiled code was generated.
-- Q values provide information about the state of the compilation queues when the compilation occurred.
-- bcsz shows the bytecode size. In this case it is small because this is a native method, so the JIT is simply providing an accelerated JNI transition into the native getCallerClass method.
+- The method compiled is `sun/reflect/Reflection.getCallerClass()Ljava/lang/Class`.
+- The `+` indicates that this method is successfully compiled. Failed compilations are marked by a `!`.
+- `(cold)` tells you the optimization level that was applied. Other examples might be `(warm)` or `(scorching)`.
+- `00007FCACED1303C-00007FCACED13182` is the code range where the compiled code was generated.
+- `Q` values provide information about the state of the compilation queues when the compilation occurred.
+- `bcsz` shows the bytecode size. In this case it is small because this is a native method, so the JIT is simply providing an accelerated JNI transition into the native `getCallerClass` method.
 
 Each line of output represents a method that is compiled.
 

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -308,7 +308,7 @@ The following summary data is displayed:
 : The number of bytes of non-class data stored by the VM.
 
 #### `Metadata bytes`
-: The number of bytes of data stored to describe the cached classes. **Note:** This field is available only in the top layer cache output or when a cache is not layered.
+: The number of bytes of data stored to describe the cached classes. <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** This field is available only in the top layer cache output or when a cache is not layered.
 
 #### `Metadata % used`
 : The proportion of metadata bytes to class bytes, which indicates how efficiently cache space is being used. The value shown does consider the `Class debug area size`.
@@ -417,3 +417,6 @@ Cache is 8% full
 
 Cache is accessible to current user = true
 ```
+
+
+<!-- ==== END OF TOPIC ==== shrc_diag_util.md ==== -->

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -53,7 +53,7 @@ Options that change the behavior of the Garbage Collector (GC).
 
 ### `concurrentScavenge`
 
-**(64-bit: Windows, AIX, Linux (x86, POWER&reg;, or IBM Z&reg;), macOS&reg;, and z/OS&reg;)**
+**(64-bit only)**
 
         -Xgc:concurrentScavenge
 
@@ -137,6 +137,8 @@ Options that change the behavior of the Garbage Collector (GC).
 : The maximum percentage of the heap that can be contracted at any given time. For example, `-Xgc:maxContractPercent=20` causes the heap to contract by as much as 20%.
 
 ### `noConcurrentScavenge`
+
+**(64-bit only)**
 
         -Xgc:noConcurrentScavenge
 


### PR DESCRIPTION
Minor updates as follows (inc. links to staged changes):
- Change link in introduction.md for GPU overview topic from SDK to VM ref ( https://eclipse.github.io/openj9-docs-staging/440/introduction/#exploiting-gpus )
- Correct platform support for concurrent scavenge mode of gencon GC policy ( https://eclipse.github.io/openj9-docs-staging/440/xgc/#concurrentscavenge )
- Correct format of long line of code in jit.md ( https://eclipse.github.io/openj9-docs-staging/440/jit/ )
- Correct codeblock content in env_var.md ( https://eclipse.github.io/openj9-docs-staging/440/env_var/#dump-agent-options)

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>