### PR TITLE
Pull docker image before running

### DIFF
--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -81,6 +81,7 @@ timeout(time: 6, unit: 'HOURS') {
                 def TMP_DESC = (currentBuild.description) ? currentBuild.description + "<br>" : ""
                 currentBuild.description = TMP_DESC + "<a href=${JENKINS_URL}computer/${NODE_NAME}>${NODE_NAME}</a>"
 
+                docker.image("${NAMESPACE}/${CONTAINER_NAME}:latest").pull()
                 docker.image("${NAMESPACE}/${CONTAINER_NAME}:latest").inside() {
                     stage('Build Doc') {
                         dir(BUILD_DIR) {


### PR DESCRIPTION
- By default if the image exists on the
  machine, the run will not update it.
  Adding a pull will force an update
  before running it.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>