### PR TITLE
Add Google Analytics tracking code

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ site_description: Eclipse OpenJ9 documentation
 
 # copyright: '© 2017, 2018 IBM Corp. and others'
 
-# google_analytics: ['UA-105616558-1', 'mkdocs.org']
+google_analytics: ['UA-105616558-3', 'mkdocs.org']
 
 # Build directories
 


### PR DESCRIPTION
Add tag for Google Analytics. The data is anonymized
by Mkdocs-Material, which is an Eclipse requirement for tracking data
on this project.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>