### PR TITLE
Apply CSS changes for updated dependency levels

### DIFF
--- a/docs/stylesheets/oj9.css
+++ b/docs/stylesheets/oj9.css
@@ -143,7 +143,7 @@
   font-weight: 600;
 }
 .md-typeset h3 code {
-  font-size: 1.9rem;
+  font-size: 0.95rem;
 }
 
 .md-nav__title {
@@ -162,8 +162,8 @@ margin-top: 5rem;
 /* HEADER */
 
 .md-header {
-  height: 4.8rem;
-  padding: .3rem 0rem 5rem 0rem;
+  height: 2.4rem;
+  padding: .15rem 0rem 2.5rem 0rem;
 }
 
 /* Logo in the header - container */
@@ -174,7 +174,7 @@ margin-top: 5rem;
 }
 
 .egg {
-  height: 4rem;
+  height: 2rem;
   transition: opacity .4s;
   position: absolute;
   top: 50%;
@@ -225,7 +225,7 @@ margin-top: 5rem;
 
 @media only screen and (min-width: 76.25em) {
   .md-sidebar__inner {
-    border-right: .2rem solid rgba(0,0,0,.1);
+    border-right: .1rem solid rgba(0,0,0,.1);
   }
 }
 
@@ -245,7 +245,7 @@ html .md-footer-meta.md-typeset a:hover {
 }
 
 .md-footer-social__link:before {
-    font-size: 3rem;
+    font-size: 1.5rem;
 }
 .md-footer-social__link:hover:before {
   color: #da7a08;                      /* orange - Eclipse button: hover */
@@ -253,9 +253,9 @@ html .md-footer-meta.md-typeset a:hover {
 
 
 div .md-footer-copyright__highlight p {
-	font-size:1.9rem;
+	font-size:0.95rem;
 	-webkit-margin-before: 0rem;
-	-webkit-margin-after : .6rem;
+	-webkit-margin-after : .3rem;
 }
 
 .md-footer-meta.md-typeset {
@@ -263,28 +263,28 @@ div .md-footer-copyright__highlight p {
 }
 .md-footer-copyright1 {
   text-align: left;
-  font-size: 1.3rem;
-  padding: 1rem 5rem 0 5rem;
+  font-size: 0.75rem;
+  padding: 0.5rem 2.5rem 0 2.5rem;
 }
 .md-footer-social1 {
 
 }
 .md-footer-eclipse1 {
-  padding: 1rem 0 1rem 0;
+  padding: 0.5rem 0 0.5rem 0;
 }
 .md-footer-links1 {
-  font-size: 1.5rem;
+  font-size: 0.8rem;
   color: rgba(0,0,0,.5);
 }
 .md-footer-links1 .dark-link {
-  padding-left: .4rem;
+  padding-left: .2rem;
 }
 
 
 .md-footer-power1 {
   text-align: right;
-  font-size: 1.3rem;
-  padding: 0 5rem 0 5rem;
+  font-size: 0.65rem;
+  padding: 0 2.5rem 0 2.5rem;
 }
 
 
@@ -327,12 +327,12 @@ i.fa-chevron-circle-right {
 }
 
 .md-footer-nav__link {
-  padding-top: 3rem;
+  padding-top: 1.5rem;
 }
 
 .md-footer-nav__button {
   margin-left: 0;
-  margin-right: 1rem;
+  margin-right: 0.5rem;
   padding-left: 0;
   padding-right: 0;
 }
@@ -356,17 +356,17 @@ i.fa-chevron-circle-right {
 
 aside {
   background-color: #ddffee;
-  padding: 0 0 .3rem 0;
+  padding: 0 0 .15rem 0;
   margin: 0 0 0 0;
 }
 aside p {
-  padding: 0rem .8rem 0rem 1rem;
-  font-size: 1.3rem;
+  padding: 0rem .4rem 0rem 0.5rem;
+  font-size: 0.65rem;
   }
 aside p:first-child {
-  padding: .6rem .8rem .6rem 1rem;
+  padding: .3rem .4rem .3rem 0.5rem;
   background-color: #bbffcc;
-  font-size: 1.5rem;
+  font-size: 0.75rem;
   font-weight: bold;
 }
 
@@ -378,8 +378,8 @@ aside p:first-child {
 /* TABLES */
 
 .md-typeset table:not([class]) th {
-  min-width: 10rem;
-  padding: .4rem 1.6rem;
+  min-width: 5rem;
+  padding: .2rem 0.8rem;
   background-color: #888888;
   color: #fff;
   vertical-align: top;
@@ -392,8 +392,8 @@ aside p:first-child {
 }
 
 .md-typeset table:not([class]) td {
-  padding: .5rem 1.6rem;
-  border-top: .1rem solid rgba(0,0,0,.07);
+  padding: .25rem 0.8rem;
+  border-top: .05rem solid rgba(0,0,0,.07);
   vertical-align: top;
 }
 
@@ -425,7 +425,7 @@ body > div > main > div > div.md-sidebar.md-sidebar--secondary > div > div > nav
 
 /* Just tweak in-line icons a bit! */
 img {
-	vertical-align: -.2rem;
+	vertical-align: -.1rem;
 }
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ markdown_extensions:
 # Documentation layout
 
 # nav:   # "pages:" --> "nav:" for MkDocs 1.0
-pages:
+nav:
 
     - "About"                                                                    : index.md
     - "AdoptOpenJDK builds"                                                      : adoptopenjdk.md

--- a/theme/base.html
+++ b/theme/base.html
@@ -71,9 +71,9 @@
       {% endif %}
     {% endblock %}
     {% block styles %}
-      <link rel="stylesheet" href="{{ 'assets/stylesheets/application.451f80e5.css' | url }}">
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/application.1b62728e.css' | url }}">
       {% if palette.primary or palette.accent %}
-        <link rel="stylesheet" href="{{ 'assets/stylesheets/application-palette.22915126.css' | url }}">
+        <link rel="stylesheet" href="{{ 'assets/stylesheets/application-palette.a8b3c06d.css' | url }}">
       {% endif %}
       {% if palette.primary %}
         {% import "partials/palette.html" as map %}
@@ -84,7 +84,7 @@
       {% endif %}
     {% endblock %}
     {% block libs %}
-      <script src="{{ 'assets/javascripts/modernizr.1aa3b519.js' | url }}"></script>
+      <script src="{{ 'assets/javascripts/modernizr.268332fc.js' | url }}"></script>
     {% endblock %}
     {% block fonts %}
       {% if font != false %}
@@ -107,7 +107,7 @@ new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f (https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore%28j,f) );
 })(window,document,'script','dataLayer','GTM-5WLCZXC');</script>
-<!-- End Google Tag Manager -->  
+<!-- End Google Tag Manager -->
   </head>
   {% if palette.primary or palette.accent %}
     {% set primary = palette.primary | replace(" ", "-") | lower %}
@@ -215,7 +215,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       {% endblock %}
     </div>
     {% block scripts %}
-      <script src="{{ 'assets/javascripts/application.583bbe55.js' | url }}"></script>
+      <script src="{{ 'assets/javascripts/application.a8b5e56f.js' | url }}"></script>
       {% if lang.t("search.language") != "en" %}
         {% set languages = lang.t("search.language").split(",") %}
         {% if languages | length and languages[0] != "" %}

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -22,45 +22,45 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <header class="md-header" data-md-component="header">
-  <nav class="md-header-nav md-grid">
-    <div class="md-flex">
-      <div class="md-flex__cell md-flex__cell--shrink">
-        <a href="{{ config.site_url | default(nav.homepage.url, true) }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo">
-          {% if config.theme.logo.icon %}
-            <i class="md-icon">{{ config.theme.logo.icon }}</i>
-          {% else %}
-            <img src="{{ base_url }}/{{ config.theme.logo }}">
-          {% endif %}
-        </a>
-      </div>
-      <div class="md-flex__cell md-flex__cell--shrink">
-        <label class="md-icon md-icon--menu md-header-nav__button" for="__drawer"></label>
-      </div>
-      <div class="md-flex__cell md-flex__cell--stretch">
-        <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
-        </div>
-      </div>
-      <div class="md-flex__cell md-flex__cell--shrink">
-        {% block search_box %}
-          {% if "search" in config["plugins"] %}
-            <label class="md-icon md-icon--search md-header-nav__button" for="search"></label>
-            {% include "partials/search.html" %}
-          {% endif %}
-        {% endblock %}
-      </div>
-      {% if config.repo_url %}
+    <nav class="md-header-nav md-grid">
+      <div class="md-flex">
         <div class="md-flex__cell md-flex__cell--shrink">
-          <div class="md-header-nav__source">
-            {% include "partials/source.html" %}
+          <a href="{{ config.site_url | default(nav.homepage.url, true) }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo">
+            {% if config.theme.logo.icon %}
+              <i class="md-icon">{{ config.theme.logo.icon }}</i>
+            {% else %}
+              <img src="{{ base_url }}/{{ config.theme.logo }}">
+            {% endif %}
+          </a>
+        </div>
+        <div class="md-flex__cell md-flex__cell--shrink">
+          <label class="md-icon md-icon--menu md-header-nav__button" for="__drawer"></label>
+        </div>
+        <div class="md-flex__cell md-flex__cell--stretch">
+          <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           </div>
         </div>
-      {% endif %}
+        <div class="md-flex__cell md-flex__cell--shrink">
+          {% block search_box %}
+            {% if "search" in config["plugins"] %}
+              <label class="md-icon md-icon--search md-header-nav__button" for="search"></label>
+              {% include "partials/search.html" %}
+            {% endif %}
+          {% endblock %}
+        </div>
+        {% if config.repo_url %}
+          <div class="md-flex__cell md-flex__cell--shrink">
+            <div class="md-header-nav__source">
+              {% include "partials/source.html" %}
+            </div>
+          </div>
+        {% endif %}
 
-      <!-- Eclipse Incubator link -->
-      <div class="md-flex__cell md-flex__cell--shrink">
-        <a href="http://wiki.eclipse.org/Development_Resources/Process_Guidelines/What_is_Incubation" target="_blank"><img class="egg" src="{{ base_url }}/cr/egg-incubation.png" alt="Eclipse Incubation"></a>
+        <!-- Eclipse Incubator link -->
+        <div class="md-flex__cell md-flex__cell--shrink">
+          <a href="http://wiki.eclipse.org/Development_Resources/Process_Guidelines/What_is_Incubation" target="_blank"><img class="egg" src="{{ base_url }}/cr/egg-incubation.png" alt="Eclipse Incubation"></a>
+        </div>
+
       </div>
-
-    </div>
-  </nav>
-</header>
+    </nav>
+  </header>


### PR DESCRIPTION
OpenJ9-docs build tools were updated earlier this week to move
up dependency levels. A new docker image was created and pushed
to the Docker hub Eclipse area. Draft docs are already built with
these levels, but required CSS changes.

The openj9-docs-0.17.0 branch was then updated to add in Google
Analytics tagging, but the HTML was rebuilt with the later build tool
levels and without the required CSS changes, causing the docs to render
incorrectly.

The same CSS changes are now applied to the branch. This has been
tested with a local build successfully.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>