### PR TITLE
Update what's new for v0.18.1 binaries

### DIFF
--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -50,6 +50,7 @@
  OpenJ9 release 0.15.0 and 0.15.1 supports OpenJDK 8, 11, and 12.
 
  Binaries are available from the AdoptOpenJDK community at the following links:
+
 - [OpenJDK version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
 - [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 - [OpenJDK version 12](https://adoptopenjdk.net/archive.html?variant=openjdk12&jvmVariant=openj9)

--- a/docs/version0.18.md
+++ b/docs/version0.18.md
@@ -23,7 +23,7 @@
 -->
 
 
-# What's new in version 0.18.0
+# What's new in version 0.18.1
 
 The following new features and notable changes since v 0.17.0 are included in this release:
 
@@ -49,11 +49,13 @@ The following new features and notable changes since v 0.17.0 are included in th
 
 ### Binaries and supported environments
 
-OpenJ9 release 0.18.0 supports OpenJDK 8, 11, and 13. Binaries are available from the AdoptOpenJDK community at the following links:
+OpenJ9 releases 0.18.0 and 0.18.1 support OpenJDK 8, 11, and 13. Binaries are available from the AdoptOpenJDK community at the following links:
 
 - [OpenJDK version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
 - [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 - [OpenJDK version 13](https://adoptopenjdk.net/archive.html?variant=openjdk13&jvmVariant=openj9)
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Binaries at AdoptOpenJDK that are labeled 0.18.1 include additional bug fixes. For more information, see the [release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.18/0.18.md).
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 


### PR DESCRIPTION
Additional fixes are included for Java 8 & 11, resulting in
binaries at AdoptOpenJDK for v0.18.1. Explanation added to the
what's new topic.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>