### PR TITLE
Add in missing Number Startup Hint Entries on javadump page

### DIFF
--- a/docs/dump_javadump.md
+++ b/docs/dump_javadump.md
@@ -620,6 +620,7 @@ NULL
 2SCLTEXTNTK        Number Tokens                             = 0
 2SCLTEXTNOJ        Number Java Objects                       = 0
 2SCLTEXTNZC        Number Zip Caches                         = 5
+2SCLTEXTNSH        Number Startup Hint Entries               = 0
 2SCLTEXTNJC        Number JCL Entries                        = 0
 2SCLTEXTNST        Number Stale classes                      = 0
 2SCLTEXTPST        Percent Stale classes                     = 0%


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9-docs/issues/491

The line: `2SCLTEXTNSH            Number Startup Hint Entries               = 0` is missing from the `SHARED CLASSES subcomponent dump routine` section on https://www.eclipse.org/openj9/docs/dump_javadump/#shared-classes.