### PR TITLE
INACTIVE: Update docs for Class Relationship Verification Snippets

### DIFF
--- a/docs/dump_javadump.md
+++ b/docs/dump_javadump.md
@@ -599,6 +599,7 @@ NULL
 2SCLTEXTNOB        Java Object bytes                         = 0
 2SCLTEXTZCB        Zip cache bytes                           = 919328
 2SCLTEXTSHB        Startup hint bytes                        = 0
+2SCLTEXTCSB        CRV Snippet bytes                         = 0
 2SCLTEXTRWB        ReadWrite bytes                           = 114080
 2SCLTEXTJCB        JCL data bytes                            = 0
 2SCLTEXTBDA        Byte data bytes                           = 0
@@ -621,6 +622,7 @@ NULL
 2SCLTEXTNOJ        Number Java Objects                       = 0
 2SCLTEXTNZC        Number Zip Caches                         = 5
 2SCLTEXTNSH        Number Startup Hint Entries               = 0
+2SCLTEXTNCS        Number CRV Snippets                       = 0
 2SCLTEXTNJC        Number JCL Entries                        = 0
 2SCLTEXTNST        Number Stale classes                      = 0
 2SCLTEXTPST        Percent Stale classes                     = 0%
@@ -712,6 +714,7 @@ NULL
 2SCLTEXTNOB            Java Object bytes                         = 0
 2SCLTEXTZCB            Zip cache bytes                           = 1134016
 2SCLTEXTSHB            Startup hint bytes                        = 0
+2SCLTEXTCSB            CRV Snippet bytes                         = 0
 2SCLTEXTJCB            JCL data bytes                            = 0
 2SCLTEXTBDA            Byte data bytes                           = 0
 NULL
@@ -728,6 +731,7 @@ NULL
 2SCLTEXTNOJ            Number Java Objects                       = 0
 2SCLTEXTNZC            Number Zip Caches                         = 21
 2SCLTEXTNSH            Number Startup Hint Entries               = 0
+2SCLTEXTNCS            Number CRV Snippets                       = 0
 2SCLTEXTNJC            Number JCL Entries                        = 0
 2SCLTEXTNST            Number Stale classes                      = 0
 2SCLTEXTPST            Percent Stale classes                     = 0%

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -118,6 +118,10 @@ Each entry in the output starts with a VM ID, so you can see which VM wrote the 
         1: 0x000000002237C6E0 STARTUP HINTS KEY: -Xoptionsfile=jre\bin\compressedrefs\options.default -Xlockword:mode=default -Xjcl:jclse29 -Dcom.ibm.oti.vm.bootstrap.library.path=jre\bin\compressedrefs;jre\bin -Djava.home=jre -Djava.ext.dirs=jre\lib\ext -Duser.dir=bin -Djava.class.path=. -Dsun.java.launcher=SUN_STANDARD Address: 0x000000002237C700 Size: 96
         STARTUP HINTS DETAIL Flags: 1 DATA1: 1677721 DATA2: 5033165
 
+### CRV Snippets
+: Information about Class Relationship Verifier (CRV) snippets is shown in `CRV SNIPPET KEY`. For example:
+
+        1: 0x000000001CA23BD0 CRV SNIPPET KEY: Foo Address: 0x000000001CA23BF0 Size: 43
 
 ## `printStats`
 
@@ -144,6 +148,7 @@ You can request more detail about items of a specific data type that are stored 
 -   `zipcache`
 -   `stale`
 -   `startuphint`
+-   `crvsnippet`
 
 Example output for a traditional cache (no cache layers: `cache layer = 0`), with summary information only:
 
@@ -181,6 +186,7 @@ AOT bytes                            = 98404
 JIT data bytes                       = 168
 Zip cache bytes                      = 1133704
 Startup hint bytes                   = 0
+CRV Snippet bytes                    = 0
 Data bytes                           = 114080
 
 # ROMClasses                         = 452
@@ -190,6 +196,7 @@ Data bytes                           = 114080
 # Tokens                             = 0
 # Zip caches                         = 21
 # Startup hints                      = 0
+# CRV Snippets                       = 0
 # Stale classes                      = 0
 % Stale classes                      = 0%
 
@@ -239,6 +246,7 @@ AOT bytes                            = 128924
 JIT data bytes                       = 812
 Zip cache bytes                      = 1133704
 Startup hint bytes                   = 0
+CRV Snippet bytes                    = 0
 Data bytes                           = 114080
 
 # ROMClasses                         = 452
@@ -248,6 +256,7 @@ Data bytes                           = 114080
 # Tokens                             = 0
 # Zip caches                         = 21
 # Startup hints                      = 0
+# CRV Snippets                       = 0
 # Stale classes                      = 0
 % Stale classes                      = 0%
 ```
@@ -304,6 +313,9 @@ The following summary data is displayed:
 #### `Startup hint bytes`
 : The number of bytes of data stored to describe startup hints.
 
+#### `CRV Snippet bytes`
+: The number of bytes of data stored to describe Class Relationship Verifier Snippets.
+
 #### `Data bytes`
 : The number of bytes of non-class data stored by the VM.
 
@@ -338,6 +350,9 @@ The following summary data is displayed:
 
 #### `Startup hints`
 : The number of startup hints stored in the cache. There can be a startup hint for each unique set of command line options used to start the JVM.
+
+#### `CRV Snippets`
+: The number of Class Relationship Verifier Snippets stored in the cache. There can be a snippet stored for each class relationship asserted in an application's bytecodes.
 
 #### `Stale classes`
 : The number of classes that have been marked as "potentially stale" by the cache code, because of a VM or Java application update. See [Understanding dynamic updates](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/shrc_pd_dynamic.html).
@@ -400,6 +415,7 @@ AOT bytes                            = 30520
 JIT data bytes                       = 644
 Zip cache bytes                      = 0
 Startup hint bytes                   = 0
+CRV Snippet bytes                    = 0
 Data bytes                           = 114080
 
 # ROMClasses                         = 0
@@ -409,6 +425,7 @@ Data bytes                           = 114080
 # Tokens                             = 0
 # Zip caches                         = 0
 # Startup hints                      = 0
+# CRV Snippets                       = 0
 # Stale classes                      = 0
 % Stale classes                      = 0%
 

--- a/docs/xfuture.md
+++ b/docs/xfuture.md
@@ -34,7 +34,7 @@ As described in the [Oracle "Non-Standard Options" documentation](https://docs.o
 
 Oracle recommend that you use this flag when you are developing new code because stricter checks will become the default in future releases.
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** You cannot use this setting in conjunction with [-XX:+ClassRelationshipVerifier](xxclassrelationshipverifier.md). 
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** You cannot use this setting in conjunction with [-XX:+ClassRelationshipVerifier](xxclassrelationshipverifier.md) or [`-XX:+ClassRelationshipVerifierIgnoreSCC`](xxclassrelationshipverifierignorescc.md).
 
 ## Default behavior
 

--- a/docs/xverify.md
+++ b/docs/xverify.md
@@ -31,7 +31,7 @@ As described in the [Oracle documentation](https://docs.oracle.com/javase/8/docs
 | Setting           | Effect | Default |
 |-------------------|--------|:-------:|
 | `-Xverify`        | Enables verification for all non-bootstrap classes. [`-Xfuture`](xfuture.md) verification is not enabled. | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
-| `-Xverify:all`    | Enables verification for all classes and enables [`-Xfuture`](xfuture.md) verification. &nbsp; You cannot use this setting in conjunction with [-XX:+ClassRelationshipVerifier](xxclassrelationshipverifier.md). &nbsp; **Note:** This setting might have an impact on performance. | |
+| `-Xverify:all`    | Enables verification for all classes and enables [`-Xfuture`](xfuture.md) verification. &nbsp; You cannot use this setting in conjunction with [-XX:+ClassRelationshipVerifier](xxclassrelationshipverifier.md) or [`-XX:+ClassRelationshipVerifierIgnoreSCC`](xxclassrelationshipverifierignorescc.md). &nbsp; **Note:** This setting might have an impact on performance. | |
 | `-Xverify:remote` | For compatibility, this parameter is accepted, but is equivalent to the default `-Xverify`. | |
 | `-Xverify:none`   | Disables the verifier. &nbsp; **Note:** This is not a supported configuration and, as noted, is deprecated in Java 13 and later versions. If you encounter problems with the verifier turned off, remove this option and try to reproduce the problem. | |
 

--- a/docs/xxclassrelationshipverifierignorescc.md
+++ b/docs/xxclassrelationshipverifierignorescc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2020 IBM Corp. and others
+* Copyright (c) 2020, 2020 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,7 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -XX:[+|-]ClassRelationshipVerifier
+# -XX:[+|-]ClassRelationshipVerifierIgnoreSCC
 
 This option enables and disables the recording of class relationships in the verifier to delay validation until triggered by class loading.
 
@@ -30,16 +30,16 @@ This option enables and disables the recording of class relationships in the ver
 
 ## Syntax
 
-        -XX:[+|-]ClassRelationshipVerifier
+        -XX:[+|-]ClassRelationshipVerifierIgnoreSCC
 
-| Setting                          | Effect  | Default                                                                        |
-|----------------------------------|---------|:------------------------------------------------------------------------------:|
-| `-XX:+ClassRelationshipVerifier` | Enable  |                                                                                |
-| `-XX:-ClassRelationshipVerifier` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
+| Setting                                   | Effect  | Default                                                                        |
+|-------------------------------------------|---------|:------------------------------------------------------------------------------:|
+| `-XX:+ClassRelationshipVerifierIgnoreSCC` | Enable  |                                                                                |
+| `-XX:-ClassRelationshipVerifierIgnoreSCC` | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> |
 
 ## Explanation
 
-When enabled, this option delays validating the relationships between classes until the classes are required to be loaded during program execution. In this way, classes that are not required, are never loaded thus reducing VM startup time. This option leverages the Shared Classes Cache (SCC) in its implementation. To use the Class Relationship Verifier without the SCC, use option [`-XX:+ClassRelationshipVerifierIgnoreSCC`](xxclassrelationshipverifierignorescc.md) instead.
+When enabled, this option delays validating the relationships between classes until the classes are required to be loaded during program execution. In this way, classes that are not required, are never loaded thus reducing VM startup time. This option provides the same functionality as [`-XX:+ClassRelationshipVerifier`](xxclassrelationshipverifier.md), except that it ignores the Shared Classes Cache in its implementation.
 
 A verify error is thrown if validation fails.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -314,6 +314,7 @@ nav:
             - "-XXActiveProcessorCount"                                          : xxactiveprocessorcount.md
             - "-XXallowvmshutdown"                                               : xxallowvmshutdown.md
             - "-XX:[+|-]ClassRelationshipVerifier"                               : xxclassrelationshipverifier.md
+            - "-XX:[+|-]ClassRelationshipVerifierIgnoreSCC"                      : xxclassrelationshipverifierignorescc.md
             - "-XX:ConcGCThreads"                                                : xxconcgcthreads.md
             - "-XX:codecachetotal"                                               : xxcodecachetotal.md
             - "-XX:[+|-]CompactStrings"                                          : xxcompactstrings.md


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9-docs/issues/490
Class Relationship Verification Snippets PR: https://github.com/eclipse/openj9/pull/8420 

Changes:
- [x] Add new documentation for `-XX:[+|-]ClassRelationshipVerifierIgnoreSCC`
- [x] Update `-Xfuture` to include incompatibility with IgnoreSCC option
- [x] Update `-Xverify` to include incompatibility with IgnoreSCC option
- [x] Update `-XX:[+|-]ClassRelationshipVerifier` to refer to IgnoreSCC option if user does not want to use SCC for Class Relationship Verification
- [x] Update Shared classes cache diagnostic utilities (printStats) to include Snippets
- [x] Update Java dump to include Snippets
- [ ] Update release documentation to describe difference between `-XX:[+|-]ClassRelationshipVerifier` and `-XX:[+|-]ClassRelationshipVerifierIgnoreSCC`
- [ ] Update release documentation to note that the shared classes cache generation number has been updated, similar to: https://www.eclipse.org/openj9/docs/version0.14/#changes-to-the-shared-classes-cache-generation-number