### PR TITLE
New command line options: -XX[+|-]PrintCodeCache

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -47,7 +47,7 @@ You can use the following command-line options in OpenJ9, just as you did in Hot
 | [`-Xrs`](xrs.md)                                                 | Prevents the OpenJ9 run time environment from handling signals.                                                                              |
 | [`-Xss`](xss.md)                                                 | Sets the Java&trade; thread stack size. (Equivalent to `-XX:ThreadStackSize`). <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Unlike HotSpot, this option applies only to the Java stack. OpenJ9 has a separate native stack for operating system threads (see [`-Xmso`](xmso.md))  |
 | [`-Xverify:mode`](xverify.md)                                    | Enables or disables the verifier.                                                                                                            |
-| [`-XX:ConcGCThreads`](xxconcgcthreads.md)                        | Configures the number of GC mutator background threads.                                                                                         |
+| [`-XX:ConcGCThreads`](xxconcgcthreads.md)                        | Configures the number of GC mutator background threads.                                                                                      |
 | [`-XX:[+|-]CompactStrings`](xxcompactstrings.md)                 | Enables/disables `String` compression                                                                                                        |
 | [`-XX:[+|-]DisableExplicitGC`](xxdisableexplicitgc.md)           | Enables/disables `System.gc()` calls. (Alias for [`-Xdisableexplicitgc` / `-Xenableexplicitgc`](xenableexplicitgc.md))                       |
 | [`-XX:[+|-]ExitOnOutOfMemory`](xxexitonoutofmemory.md)           | Triggers VM shutdown on out-of-memory conditions.                                                                                            |
@@ -56,19 +56,19 @@ You can use the following command-line options in OpenJ9, just as you did in Hot
 | [`-XX:[+|-]IgnoreUnrecognizedVMOptions`](xxignoreunrecognizedvmoptions.md) | Specifies whether to ignore unrecognized top-level VM options |                                                                    |
 | [`-XX:InitialHeapSize`](xxinitialheapsize.md)                    | Sets the initial size of the heap. (Alias for [`-Xms`](xms.md))                                                                              |
 | [`-XX:InitialRAMPercentage`](xxinitialrampercentage.md)          | Sets the initial size of the Java heap as a percentage of total memory.                                                                      |
-| [`-XX:OnOutOfMemoryError`](xxonoutofmemoryerror.md)              | Runs specified commands when a `java.lang.OutOfMemoryError` is thrown. (Equivalent to `-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,exec=`) |
 | [`-XX:MaxDirectMemorySize`](xxmaxdirectmemorysize.md)            | Sets a limit on the amount of memory that can be reserved for all direct byte buffers.                                                       |
 | [`-XX:MaxHeapSize`    ](xxinitialheapsize.md)                    | Specifies the maximum size of the object memory allocation pool. (Alias for [`-Xmx`](xms.md))                                                |
-| [`-XX:MaxRAMPercentage`](xxinitialrampercentage.md)              | Sets the maximum size of the Java heap as a percentage of total memory.                                                                     |
-| [`-XX:ParallelCMSThreads`](xxparallelcmsthreads.md)                | Configures the number of GC mutator background threads.                                                                                        |
-| [`-XX:ParallelGCThreads`](xxparallelgcthreads.md)                | Configures the number of GC threads.                                                                                                                |
-| [`-XX:[+|-]UseCompressedOops`](xxusecompressedoops.md)               | Disables compressed references in 64-bit JVMs. (See also [`-Xcompressedrefs`](xcompressedrefs.md))                                           |
-| [`-XX:[+|-]UseContainerSupport`](xxusecontainersupport.md)           | Sets a larger fraction of memory to the Java heap when the VM detects that it is running in a container.                                 |
+| [`-XX:MaxRAMPercentage`](xxinitialrampercentage.md)              | Sets the maximum size of the Java heap as a percentage of total memory.                                                                      |
+| [`-XX:OnOutOfMemoryError`](xxonoutofmemoryerror.md)              | Runs specified commands when a `java.lang.OutOfMemoryError` is thrown. (Equivalent to `-Xdump:tool:events=systhrow,filter=java/lang/OutOfMemoryError,exec=`) |
+| [`-XX:ParallelCMSThreads`](xxparallelcmsthreads.md)              | Configures the number of GC mutator background threads.                                                                                      |
+| [`-XX:ParallelGCThreads`](xxparallelgcthreads.md)                | Configures the number of GC threads.                                                                                                         |
+| [`-XX:[+|-]PrintCodeCache`](xxprintcodecache.md)                 | Prints code cache usage when the application exits.                                                                                          |
+| [`-XX:[+|-]UseCompressedOops`](xxusecompressedoops.md)           | Disables compressed references in 64-bit JVMs. (See also [`-Xcompressedrefs`](xcompressedrefs.md))                                           |
+| [`-XX:[+|-]UseContainerSupport`](xxusecontainersupport.md)       | Sets a larger fraction of memory to the Java heap when the VM detects that it is running in a container.                                     |
 
 
 
 
--XX:[+|-]CompactStrings
 
 
 

--- a/docs/version0.19.md
+++ b/docs/version0.19.md
@@ -28,6 +28,7 @@
  The following new features and notable changes since v 0.18.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Option to print code cache usage on stderr at JVM shutdown](#option-to-print-code-cache-usage-on-stderr-at-JVM-shutdown)
 - [xxxx](#xxxx)
 
 ## Features and changes
@@ -43,6 +44,10 @@ OpenJDK 14 with Eclipse OpenJ9 is not a long term support (LTS) release.
 The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK community are for Eclipse OpenJ9 release 0.18.0. Features mentioned in these release notes are not available in these builds. Although it might be possible to build an OpenJDK 8 or OpenJDK 11 with OpenJ9 0.18.0, testing at the project is not complete and therefore support for any of these features is not available.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Option to print code cache usage on stderr at JVM shutdown
+
+A new command line option [-XX:+PrintCodeCache](xxprintcodecache.md) allows you to print the code cache memory usage on stderr at JVM shutdown.
 
 ### xxxx
 

--- a/docs/xxprintcodecache.md
+++ b/docs/xxprintcodecache.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2020, 2020 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:\[+|-\]PrintCodeCache
+
+This Oracle HotSpot option prints the code cache memory usage when the application exits. This option is recognized by OpenJ9 and provided for compatibility.
+
+## Syntax
+
+        -XX:[+|-]PrintCodeCache
+
+| Setting                      | Effect  | Default                                                                            |
+|------------------------------|---------|:----------------------------------------------------------------------------------:|
+| `-XX:+PrintCodeCache`        | Enable  |                                                                                    |
+| `-XX:-PrintCodeCache`        | Disable | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
+
+As discussed in the Oracle documentation, the code cache usage can be shown when the application exits, by specifying `–XX:+PrintCodeCache` on the java launcher command line. The output looks similar to the following: 
+
+```
+CodeCache: size=262144Kb used=454Kb max_used=457Kb free=261690Kb
+```
+
+- `size`: The maximum size of the code cache.
+- `used`: The amount of code cache memory actually in use.
+- `max_used`: The high water mark for code cache usage.
+- `free`: `size` minus `used`.
+
+<!-- ==== END OF TOPIC ==== xxprintcodecache.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,6 +346,7 @@ nav:
             - "-XX:ParallelCMSThreads"                                           : xxparallelcmsthreads.md
             - "-XX:ParallelGCThreads"                                            : xxparallelgcthreads.md
             - "-XX:[+|-]PositiveIdentityHash"                                    : xxpositiveidentityhash.md
+            - "-XX:[+|-]PrintCodeCache"                                          : xxprintcodecache.md
             - "-XX:[+|-]ReadIPInfoForRAS"                                        : xxreadipinfoforras.md
             - "-XX:[+|-]ReduceCPUMonitorOverhead"                                : xxreducecpumonitoroverhead.md
             - "-XX:[+|-]RuntimeInstrumentation"                                  : xxruntimeinstrumentation.md


### PR DESCRIPTION
`-XX[+|-]PrintCodeCache` prints the code cache usage when the application exits.

Closes #499

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>