### PR TITLE
New top level releases page

### DIFF
--- a/docs/openj9_releases.md
+++ b/docs/openj9_releases.md
@@ -1,0 +1,34 @@
+<!--
+* Copyright (c) 2017, 2020 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# Overview
+
+
+New releases of OpenJ9 are set to coincide with critical patch updates and new versions of the Java&trade; SE class libraries. To learn more about when these releases take place, and the OpenJ9 support lifecycle, see [Supported environments](https://www.eclipse.org/openj9/docs/openj9_support/).
+
+If you are interested in the content of future releases, plans are published in the [Eclipse OpenJ9 project page](https://projects.eclipse.org/projects/technology.openj9).
+
+High level information about the features and changes in final releases of OpenJ9 can be found in the topics that follow.
+
+<!-- ==== END OF TOPIC ==== openj9_releases.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
     - "New to OpenJ9?"                                                           : openj9_newuser.md
 
     - "Release notes" :
+        - "Overview"                                                             : openj9_releases.md
         - "Version 0.19.0"                                                       : version0.19.md
         - "Version 0.18.1"                                                       : version0.18.md
         - "Version 0.17.0"                                                       : version0.17.md


### PR DESCRIPTION
Page to introduce OpenJ9 releases and provide links to
the Eclipse project page and support lifecycle.

There will be a link to this page from the redesigned
OpenJ9 site (news page)

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>