### PR TITLE
Update 'Supported environments' topic for OpenJDK 14

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -74,7 +74,7 @@ reasons the Eclipse OpenJ9 JVM does not currently run on every platform.
 <i class="fa fa-bell" aria-hidden="true"></i> **Important:** If you obtain pre-built binaries from [AdoptOpenJDK.net](https://adoptopenjdk.net/index.html),
 platform support might vary, depending on their build environment. Check the AdoptOpenJDK [Platform support matrix](https://adoptopenjdk.net/supported_platforms.html).
 
-OpenJDK8 binaries are supported on the minimum operating system levels shown in the following tables:
+OpenJDK 8 binaries are supported on the minimum operating system levels shown in the following tables:
 
 | Linux&reg;                            |   x32  |  x64   | ppc64le    | Z31  | Z64 |
 |---------------------------------------|--------|--------|------------|------|------|
@@ -114,7 +114,7 @@ When public support for an operating system version ends, OpenJ9 can no longer b
 <i class="fa fa-bell" aria-hidden="true"></i> **Important:** If you obtain pre-built binaries from [AdoptOpenJDK.net](https://adoptopenjdk.net/index.html),
 platform support might vary, depending on their build environment. Check the AdoptOpenJDK [Platform support matrix](https://adoptopenjdk.net/supported_platforms.html).
 
-OpenJDK11 binaries are supported on the minimum operating system levels shown in the following tables:
+OpenJDK 11 binaries are supported on the minimum operating system levels shown in the following tables:
 
 
 | Linux                                 |  x64   |  ppc64le   | Z64  |
@@ -155,7 +155,50 @@ When public support for an operating system version ends, OpenJ9 can no longer b
 <i class="fa fa-bell" aria-hidden="true"></i> **Important:** If you obtain pre-built binaries from [AdoptOpenJDK.net](https://adoptopenjdk.net/index.html),
 platform support might vary, depending on their build environment. Check the AdoptOpenJDK [Platform support matrix](https://adoptopenjdk.net/supported_platforms.html).
 
-OpenJDK13 binaries are supported on the minimum operating system levels shown in the following tables:
+OpenJDK 13 binaries are supported on the minimum operating system levels shown in the following tables:
+
+
+| Linux                                 |  x64   |  ppc64le   | Z64  |
+|---------------------------------------|--------|------------|------|
+| Centos 6.9                            |   Y    |     Y      |  N   |
+| Centos 7.4                            |   Y    |     Y      |  N   |
+| Red Hat Enterprise Linux (RHEL) 6.9   |   Y    |     Y      |  Y   |
+| RHEL 7.4                              |   Y    |     Y      |  Y   |
+| SUSE Linux Enterprise Server (SLES) 12|   Y    |     Y      |  Y   |
+| Ubuntu 16.04                          |   Y    |     Y      |  Y   |
+| Ubuntu 18.04                          |   Y    |     Y      |  Y   |
+
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Not all of these distributions are tested, but Linux distributions that have a
+minimum glibc version 2.12 are expected to function without problems.
+
+| Windows                    |  x64   |
+|----------------------------|--------|
+| Windows 8.1                |   Y    |
+| Windows 10                 |   Y    |
+| Windows Server 2012        |   Y    |
+| Windows Server 2012 R2     |   Y    |
+| Windows Server 2016        |   Y    |
+
+| macOS                   |   x64    |
+|-------------------------|----------|
+| OS X 10.9.0+            |    Y     |
+
+| AIX          |  ppc64   |
+|--------------|----------|
+| AIX 7.1 TL4  |    Y     |
+| AIX 7.2      |    Y     |
+
+<i class="fa fa-bell" aria-hidden="true"></i> **Important:** AIX OpenJ9 builds require the [XL C++ Runtime](https://www.ibm.com/support/pages/xl-cc-runtime-aix-v16101-fix-pack-december-2018)
+
+When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
+
+
+### OpenJDK 14
+
+<i class="fa fa-bell" aria-hidden="true"></i> **Important:** If you obtain pre-built binaries from [AdoptOpenJDK.net](https://adoptopenjdk.net/index.html),
+platform support might vary, depending on their build environment. Check the AdoptOpenJDK [Platform support matrix](https://adoptopenjdk.net/supported_platforms.html).
+
+OpenJDK 14 binaries are supported on the minimum operating system levels shown in the following tables:
 
 
 | Linux                                 |  x64   |  ppc64le   | Z64  |
@@ -221,6 +264,18 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 | AIX POWER BE 64-bit         | AIX 7.1 TL04             | xlc/C++ 13.1.3                  |
 
 ### OpenJDK 13
+
+| Platform                    | Operating system         |  Compiler                       |
+|-----------------------------|--------------------------|---------------------------------|
+| Linux x86 64-bit            | Ubuntu 16.04             | gcc 7.3                         |
+| Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 7.3                         |
+| Linux on IBM Z 64-bit       | Ubuntu 16.04             | gcc 7.4                         |
+| Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2017    |
+| macOS x86 64-bit            | macOS 10.13.5            | xcode/clang 9.4                 |
+| AIX POWER BE 64-bit         | AIX 7.1 TL04             | xlc/C++ 16.1.0                  |
+
+
+### OpenJDK 14
 
 | Platform                    | Operating system         |  Compiler                       |
 |-----------------------------|--------------------------|---------------------------------|


### PR DESCRIPTION
In openj9_support.md, extra sections added under both
'Platform support' and 'Build environments' for OpenJDK 14.

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>