### PR TITLE
The default value of `-Xmx` is changed in Java 8

### DIFF
--- a/docs/openj9_defaults.md
+++ b/docs/openj9_defaults.md
@@ -89,11 +89,10 @@ The last 2 columns show whether the default setting can be changed by a command-
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
 
-The default value of [`-Xmx`](xms.md) depends on the version of Java.
+The default value of [`-Xmx`](xms.md) :
 
-- ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) The value is half the available memory with a minimum of 16MB and a maximum of 512 MB. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
+- The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB.
 
-
-- ![Start of content that applies only to Java 11 and later](cr/java11plus.png) The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. ![End of content that applies only to Java 11 and later](cr/java_close.png)
+- ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) If you have set the [-XX:+OriginalJDK8HeapSizeCompatibilityMode](xxoriginaljdk8heapsizecompatibilitymode.md) option for compatibility with earlier releases, the value is half the available memory with a minimum of 16 MB and a maximum of 512 MB. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
 *Available memory* is defined as being the smallest of two values: The real or *physical* memory or the *RLIMIT_AS* value.

--- a/docs/xxoriginaljdk8heapsizecompatibilitymode.md
+++ b/docs/xxoriginaljdk8heapsizecompatibilitymode.md
@@ -1,0 +1,40 @@
+<!--
+* Copyright (c) 2020, 2020 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:\[+|-\]OriginalJDK8HeapSizeCompatibilityMode
+
+![Start of content that applies only to Java 8 (LTS)](cr/java8.png) The default value for the maximum heap size (-Xmx) is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. In OpenJ9 0.18.0 and earlier releases the default is half the available memory with a minimum of 16 MB and a maximum of 512 MB. Enable this option to revert to the earlier default value. 
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Note:** This option is deprecated.
+
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This option is supported only on Java&trade; 8. it is ignored on Java&trade; 11+.
+
+## Syntax
+
+    -XX:[+|-]OriginalJDK8HeapSizeCompatibilityMode
+
+| Setting                                     | Effect     | Default                                                                            |
+|---------------------------------------------|------------|:----------------------------------------------------------------------------------:|
+| -XX:+OriginalJDK8HeapSizeCompatibilityMode  | Enable     |                                                                                    |
+| -XX:-OriginalJDK8HeapSizeCompatibilityMode  | Disable    | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |


### PR DESCRIPTION
fix: https://github.com/eclipse/openj9-docs/issues/511

Signed-off-by: Lin Hu <linhu@ca.ibm.com>