### PR TITLE
Clarify xdump throw vs systhrow

### DIFF
--- a/docs/xdump.md
+++ b/docs/xdump.md
@@ -292,7 +292,7 @@ The following table shows the events that are available as dump agent triggers:
 | **vmstop**      | The virtual machine stops.                                                  | Exit code; for example, `filter=#129..#192#-42#255`            |
 | **load**        | A class is loaded.                                                          | Class name; for example, `filter=java/lang/String`             |
 | **unload**      | A class us unloaded.                                                        | Not applicable                                                 |
-| **throw**       | An exception is thrown.                                                     | Exception class name; for example, `filter=java/lang/OutOfMem*`|
+| **throw**       | An exception is thrown explicitly in Java code. Use 'systhrow' for unexpected VM exceptions.                                                     | Exception class name; for example, `filter=java/lang/OutOfMem*`|
 | **catch**       | An exception is caught.                                                     | Exception class name; for example, `filter=*Memory*`           |
 | **uncaught**    | A Java exception is not caught by the application.                          | Exception class name; for example, `filter=*MemoryError`       |
 | **systhrow**    | A Java exception is about to be thrown by the VM. This is different from the 'throw' event because it is only triggered for error conditions detected internally in the VM.| Exception class name; for example, `filter=java/lang/OutOfMem*`.|


### PR DESCRIPTION
It was pointed out in OpenJ9 slack that the docs are not very clear about the differences between Xdump `throw` and `systhrow` events.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>