### PR TITLE
Add new -Xmx default to release notes

### DIFF
--- a/docs/version0.20.md
+++ b/docs/version0.20.md
@@ -29,7 +29,8 @@ The following new features and notable changes since v 0.19.0 are included in th
 
 - [Binaries and supported environments](#binaries-and-supported-environments)
 - [`-XX:[+|-]ExitOnOutOfMemoryError` option behavior update](#-xx-exitonoutofmemoryerror-option-behavior-update)
-- [New GlobalLockReservation option added](#new-globallockreservation-option-added)
+- [New `-XX:[+|-]GlobalLockReservation` option added](#new-xx-globallockreservation-option-added)
+- ![Start of content that applies to Java 8](cr/java8.png) [Change to default maximum heap size for Java 8](#change-to-default-maximum-heap-size-for-java-8)
 
 
 
@@ -50,12 +51,16 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 The `-XX:[+|-]ExitOnOutOfMemoryError` option is updated to exit only on VM `OutOfMemoryErrors` instead of both VM and Java&trade; thrown errors to match the Hotspot option. See [`-XX:[+|-]ExitOnOutOfMemoryError`](xxexitonoutofmemory.md) for more details about this option.
 
-### New GlobalLockReservation option added
+### New `-XX:[+|-]GlobalLockReservation` option added
 
 **(AIX and Linux on Power systems only)**
 
-`-XX:[+|-]GlobalLockReservation` has been added as a new option. This option enables a new optimization targeted towards more efficient handling of locking and unlocking Java&trade; objects. See [-XX:[+|-]GlobalLockReservation](xxgloballockreservation.md) for more details about this option.
+Option `-XX:[+|-]GlobalLockReservation` enables a new optimization targeted towards more efficient handling of locking and unlocking Java  objects. See [`-XX:[+|-]GlobalLockReservation`](xxgloballockreservation.md) for more details about this option.
 
+### ![Start of content that applies to Java 8](cr/java8.png) Change to default maximum heap size for Java 8
+
+For consistency with Java 11, the default maximum heap size (`-Xmx`) is changed to be 25% of the available memory with a maximum of 25 GB.
+Where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. If you want to revert to the default setting in earlier releases of OpenJ9, use the [-XX:+OriginalJDK8HeapSizeCompatibilityMode](xxoriginaljdk8heapsizecompatibilitymode.md) option.
 
 ## Full release information
 

--- a/docs/xxoriginaljdk8heapsizecompatibilitymode.md
+++ b/docs/xxoriginaljdk8heapsizecompatibilitymode.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2020, 2020 IBM Corp. and others
+* Copyright (c) 2017, 2020 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -24,11 +24,9 @@
 
 # -XX:\[+|-\]OriginalJDK8HeapSizeCompatibilityMode
 
-![Start of content that applies only to Java 8 (LTS)](cr/java8.png) The default value for the maximum heap size (-Xmx) is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. In OpenJ9 0.18.0 and earlier releases the default is half the available memory with a minimum of 16 MB and a maximum of 512 MB. Enable this option to revert to the earlier default value. 
+![Start of content that applies only to Java 8 (LTS)](cr/java8.png) The default value for the maximum heap size (`-Xmx`) is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. In OpenJ9 0.18.0 and earlier releases the default is half the available memory with a minimum of 16 MB and a maximum of 512 MB. Enable this option to revert to the earlier default value.
 
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Note:** This option is deprecated.
-
-<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This option is supported only on Java&trade; 8. it is ignored on Java&trade; 11+.
+<i class="fa fa-exclamation-triangle" aria-hidden="true"></i> **Restriction:** This option is supported only on Java&trade; 8. It is ignored on Java 11 and later versions.
 
 ## Syntax
 
@@ -38,3 +36,5 @@
 |---------------------------------------------|------------|:----------------------------------------------------------------------------------:|
 | -XX:+OriginalJDK8HeapSizeCompatibilityMode  | Enable     |                                                                                    |
 | -XX:-OriginalJDK8HeapSizeCompatibilityMode  | Disable    | <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span>     |
+
+![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)


### PR DESCRIPTION
- add missing what's new item that covers change to -Xmx default on Java 8
- slight mods to other entries for consistency

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>