### PR TITLE
Edit jcmd in "What's new"

### DIFF
--- a/docs/version0.20.md
+++ b/docs/version0.20.md
@@ -31,7 +31,7 @@ The following new features and notable changes since v 0.19.0 are included in th
 - [`-XX:[+|-]ExitOnOutOfMemoryError` option behavior update](#-xx-exitonoutofmemoryerror-option-behavior-update)
 - [New `-XX:[+|-]GlobalLockReservation` option added](#new-xx-globallockreservation-option-added)
 - ![Start of content that applies to Java 8](cr/java8.png) [Change to default maximum heap size for Java 8](#change-to-default-maximum-heap-size-for-java-8)
-- [Jcmd dump with default settings](#jcmd-dump-with-default-settings)
+- [Change to `jcmd` default options](#change-to-jcmd-default-options)
 
 
 
@@ -50,7 +50,7 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 ### `-XX:[+|-]ExitOnOutOfMemoryError` option behavior update
 
-The `-XX:[+|-]ExitOnOutOfMemoryError` option is updated to exit only on VM `OutOfMemoryErrors` instead of both VM and Java&trade; thrown errors to match the Hotspot option. See [`-XX:[+|-]ExitOnOutOfMemoryError`](xxexitonoutofmemory.md) for more details about this option.
+The `-XX:[+|-]ExitOnOutOfMemoryError` option is updated to exit only on VM `OutOfMemoryErrors` instead of both VM and Java&trade; thrown errors to match the Hotspot option. See [`-XX:[+|-]ExitOnOutOfMemoryError`](xxexitonoutofmemoryerror.md) for more details about this option.
 
 ### New `-XX:[+|-]GlobalLockReservation` option added
 
@@ -63,10 +63,9 @@ Option `-XX:[+|-]GlobalLockReservation` enables a new optimization targeted towa
 For consistency with Java 11, the default maximum heap size (`-Xmx`) is changed to be 25% of the available memory with a maximum of 25 GB.
 Where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB. If you want to revert to the default setting in earlier releases of OpenJ9, use the [-XX:+OriginalJDK8HeapSizeCompatibilityMode](xxoriginaljdk8heapsizecompatibilitymode.md) option.
 
-### Jcmd dump with default settings
+### Change to `jcmd` default options
 
-Jcmd `Dump` command now supports default settings when the dump request doesn't have `:file=name` option which is similar with `Java -Xdump` default settings.
-
+The Java diagnostic command (`jcmd`) tool no longer requires a filename when used with the `Dump.java`, `Dump.snap`, or `Dump.system` options. See [`jcmd`](tool_jcmd.md) for more information about the tool.
 
 ## Full release information
 


### PR DESCRIPTION
Tidy wording for jcmd entry re default settings
(also fix broken link to xxexitonoutofmemoryerror.md)
See issue #538 and PR #545
Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>