### PR TITLE
Add AArch64 limited support

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -118,18 +118,20 @@ platform support might vary, depending on their build environment. Check the Ado
 OpenJDK 11 binaries are supported on the minimum operating system levels shown in the following tables:
 
 
-| Linux                                 |  x64   |  ppc64le   | Z64  |
-|---------------------------------------|--------|------------|------|
-| CentOS 6.9                            |   Y    |     N      |  N   |
-| CentOS 7.4                            |   Y    |     Y      |  N   |
-| Red Hat Enterprise Linux (RHEL) 6.9   |   Y    |     N      |  Y   |
-| RHEL 7.4                              |   Y    |     Y      |  Y   |
-| SUSE Linux Enterprise Server (SLES) 12|   Y    |     Y      |  Y   |
-| Ubuntu 16.04                          |   Y    |     Y      |  Y   |
-| Ubuntu 18.04                          |   Y    |     Y      |  Y   |
+| Linux (**Note 1**)                    | AArch64 (**Note 2**)    | x64   |  ppc64le   | Z64  |
+|---------------------------------------|-------------------------|-------|------------|------|
+| CentOS 6.9                            |    N                    |  Y    |     N      |  N   |
+| CentOS 7.4                            |    Y                    |  Y    |     Y      |  N   |
+| Red Hat Enterprise Linux (RHEL) 6.9   |    N                    |  Y    |     N      |  Y   |
+| RHEL 7.4                              |    Y                    |  Y    |     Y      |  Y   |
+| SUSE Linux Enterprise Server (SLES) 12|    N                    |  Y    |     Y      |  Y   |
+| Ubuntu 16.04                          |    Y                    |  Y    |     Y      |  Y   |
+| Ubuntu 18.04                          |    Y                    |  Y    |     Y      |  Y   |
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Not all of these distributions are tested, but Linux distributions that have a
-minimum glibc version 2.12 are expected to function without problems.
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
+
+1. Not all of these distributions are tested, but Linux distributions that have a minimum glibc version 2.12 are expected to function without problems.
+2. Only limited support for the 64-bit ARM architecture is currently available. For a list of known issues, see the [Release notes](https://github.com/eclipse/openj9/tree/master/doc/release-notes) for the latest version of Eclipse OpenJ9.
 
 | Windows                    |  x64   |
 |----------------------------|--------|
@@ -217,6 +219,7 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 | Platform                    | Operating system         |  Compiler                       |
 |-----------------------------|--------------------------|---------------------------------|
 | Linux x86 64-bit            | CentOS 6.10              | gcc 7.5                         |
+| Linux on ARM 64-bit         | CentOS 7                 | gcc 7.4                         |
 | Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 7.5                         |
 | Linux on IBM Z 64-bit       | RHEL 7.7                 | gcc 7.5                         |
 | Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2017    |

--- a/docs/version0.19.md
+++ b/docs/version0.19.md
@@ -28,7 +28,7 @@
  The following new features and notable changes since v 0.18.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
-- [Option to print code cache usage to `stderr` at VM shutdown](#option-to-print-code-cache-usage-to-stderr-at-VM-shutdown)
+- [Option to print code cache usage to `stderr` at VM shutdown](#option-to-print-code-cache-usage-to-stderr-at-vm-shutdown)
 - [![Start of content that applies to Java 8](cr/java8.png) `StringBuffer` and `StringBuilder` above 1 G grow to the maximum size](#stringbuffer-and-stringbuilder-above-1-g-grow-to-the-maximum-size)
 - [![Start of content that applies to Java 14+](cr/java14plus.png) **jpackage** packaging tool platform support](#jpackage-packaging-tool-platform-support)
 - [![Start of content that applies to Java 14+](cr/java14plus.png) Extended messages for `NullPointerException` not yet implemented](#extended-messages-for-nullpointerexception-not-yet-implemented)
@@ -48,7 +48,7 @@ The latest builds of OpenJDK with OpenJ9 for Java 8 and 11 at the AdoptOpenJDK c
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
-### Option to print code cache usage to stderr at VM shutdown
+### Option to print code cache usage to `stderr` at VM shutdown
 
 A new command line option [-XX:+PrintCodeCache](xxprintcodecache.md) allows you to print the code cache memory usage to `stderr` when the VM shuts down.
 

--- a/docs/version0.20.md
+++ b/docs/version0.20.md
@@ -1,4 +1,4 @@
--<!--
+<!--
 * Copyright (c) 2017, 2020 IBM Corp. and others
 *
 * This program and the accompanying materials are made
@@ -28,6 +28,7 @@
 The following new features and notable changes since v 0.19.0 are included in this release:
 
 - [Binaries and supported environments](#binaries-and-supported-environments)
+- ![Start of content that applies to Java 11](cr/java11.png) [Limited support for 64-bit Linux on ARM](#limited-support-for-64-bit-linux-on-arm)
 - [`-XX:[+|-]ExitOnOutOfMemoryError` option behavior update](#-xx-exitonoutofmemoryerror-option-behavior-update)
 - [New `-XX:[+|-]GlobalLockReservation` option added](#new-xx-globallockreservation-option-added)
 - ![Start of content that applies to Java 8](cr/java8.png) [Change to default maximum heap size for Java 8](#change-to-default-maximum-heap-size-for-java-8)
@@ -47,6 +48,11 @@ OpenJ9 release 0.20.0 supports OpenJDK 8, 11, and 14. Binaries are available fro
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
+###  ![Start of content that applies to Java 11](cr/java11.png) Limited support for 64-bit Linux on ARM
+
+Limited support is available in this release for the 64-bit ARM (AArch64) architecture. An early access build on OpenJDK 11 is available from the
+[AdoptOpenJDK community](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9). See the [OpenJ9 release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.20/0.20.md) for any known issues that are still being worked on before this
+platform is fully supported.  
 
 ### `-XX:[+|-]ExitOnOutOfMemoryError` option behavior update
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -345,6 +345,7 @@ nav:
             - "-XX:MaxHeapSize"                                                  : xxinitialheapsize.md              #redirect
             - "-XX:MaxRAMPercentage"                                             : xxinitialrampercentage.md         #redirect
             - "-XX:OnOutOfMemoryError"                                           : xxonoutofmemoryerror.md
+            - "-XX:[+|-]OriginalJDK8HeapSizeCompatibilityMode"                   : xxoriginaljdk8heapsizecompatibilitymode.md
             - "-XXnosuballoc32bitmem"                                            : xxnosuballoc32bitmem.md
             - "-XX:[+|-]PageAlignDirectMemory"                                   : xxpagealigndirectmemory.md
             - "-XX:ParallelCMSThreads"                                           : xxparallelcmsthreads.md


### PR DESCRIPTION
Release notes topic:
New bullet and section for the AArch64 support in this release.

Supported environment topics:
Add AArch64 to the OpenJDK11 support table, and incude AArch64 build system information too.

Closes: #547

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>