### PR TITLE
Add information about where to find build your own instructions

### DIFF
--- a/docs/adoptopenjdk.md
+++ b/docs/adoptopenjdk.md
@@ -23,6 +23,11 @@ If you obtain binaries from the AdoptOpenJDK community, the following pre-requis
 
 - From Eclipse OpenJ9 release 0.13.0, OpenJDK binaries for Linux and AIX platforms from the AdoptOpenJDK community no longer bundle the OpenSSL cryptographic library. The library is expected to be found on the system path. If you want to use OpenSSL cryptographic acceleration, you must install OpenSSL 1.0.2 or 1.1.X on your system. If the library is not found on the system path, the in-built Java crytographic implementation is used instead, which performs less well.  
 - ![Start of content that applies only to Java 8](cr/java8.png) On Linux systems, the `fontconfig.x86_64` package should be installed to avoid a `NullPointerException` error when the AWT font subsystem is initialized. Work is ongoing at the AdoptOpenJDK project to fix this issue for their OpenJDK binaries.
-- From Eclipse OpenJ9 release 0.16.0 (OpenJDK 13) and release 0.17.0 (OpenJDK 8 and 11), CUDA is now enabled on Windows (x86-64) and Linux (x86-64 and IBM POWER LE) platforms, which allows you to offload certain Java application processing tasks to a general purpose graphics processing unit (GPU). To take advantage of this feature, your system must support NVIDIA Compute Unified Device Architecture (CUDA). The JIT requires the CUDA Toolkit 7.5 and your GPU device must have a minimum compute capability of 3.0. 
+- From Eclipse OpenJ9 release 0.16.0 (OpenJDK 13) and release 0.17.0 (OpenJDK 8 and 11), CUDA is now enabled on Windows (x86-64) and Linux (x86-64 and IBM POWER LE) platforms, which allows you to offload certain Java application processing tasks to a general purpose graphics processing unit (GPU). To take advantage of this feature, your system must support NVIDIA Compute Unified Device Architecture (CUDA). The JIT requires the CUDA Toolkit 7.5 and your GPU device must have a minimum compute capability of 3.0.
+
+## Building your own binaries
+
+If you want to build your own binaries of OpenJDK with OpenJ9, a complete set of build instructions for several platforms can be found in the [OpenJ9 GitHub repository](https://github.com/eclipse/openj9/tree/master/doc/build-instructions).  
+
 
 <!-- ==== END OF TOPIC ==== adoptopenjdk.md ==== -->

--- a/docs/xoptionsfile.md
+++ b/docs/xoptionsfile.md
@@ -39,8 +39,8 @@ The contents of the options file are recorded in the `ENVINFO` section of a Java
 
 At startup, the VM automatically adds `-Xoptionsfile=<path>/options.default` at the beginning of the command line, where `<path>` is the path to the VM directory.
 
-![Start of content that applies only to Java 8 (LTS)](cr/java8.png) `<path>` is the VM directory, as show in [Directory conventions](openj9_directories.md).![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)  
-![Start of content that applies only to Java 11 and later](cr/java11plus.png) `<path>` is the `<java_home>/lib` directory, where `<java_home>` is the directory for your runtime environment.![End of content that applies only to Java 11 or later](cr/java_close.png)
+![Start of content that applies only to Java 8 (LTS)](cr/java8.png) `<path>` is the VM directory, as shown in [Directory conventions](openj9_directories.md). ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)  
+![Start of content that applies only to Java 11 and later](cr/java11plus.png) `<path>` is the `<java_home>/lib` directory, where `<java_home>` is the directory for your runtime environment. ![End of content that applies only to Java 11 or later](cr/java_close.png)
 
 The file `options.default` is empty but can be updated with any options that you want to specify at run time.
 


### PR DESCRIPTION
In the topic that describes the pre-built binaries, add a section
to point users to the location of our detailed build instructions for
developers who want to build their own binary.

Closes: https://github.com/eclipse/openj9-website/issues/155

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>