### PR TITLE
Update the 0.20.0 branch support statement

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -91,9 +91,7 @@ minimum glibc version 2.12 are expected to function without problems.
 
 | Windows&reg;               |  x32   |  x64  |
 |----------------------------|--------|-------|
-| Windows 8.1                |   Y    |   Y   |
 | Windows 10                 |   Y    |   Y   |
-| Windows Server 2012        |   Y    |   Y   |
 | Windows Server 2012 R2     |   Y    |   Y   |
 | Windows Server 2016        |   Y    |   Y   |
 | Windows Server 2019        |   Y    |   Y   |
@@ -135,9 +133,7 @@ OpenJDK 11 binaries are supported on the minimum operating system levels shown i
 
 | Windows                    |  x64   |
 |----------------------------|--------|
-| Windows 8.1                |   Y    |
 | Windows 10                 |   Y    |
-| Windows Server 2012        |   Y    |
 | Windows Server 2012 R2     |   Y    |
 | Windows Server 2016        |   Y    |
 | Windows Server 2019        |   Y    |
@@ -177,9 +173,7 @@ minimum glibc version 2.12 are expected to function without problems.
 
 | Windows                    |  x64   |
 |----------------------------|--------|
-| Windows 8.1                |   Y    |
 | Windows 10                 |   Y    |
-| Windows Server 2012        |   Y    |
 | Windows Server 2012 R2     |   Y    |
 | Windows Server 2016        |   Y    |
 | Windows Server 2019        |   Y    |

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -213,7 +213,7 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 | Platform                    | Operating system         |  Compiler                       |
 |-----------------------------|--------------------------|---------------------------------|
 | Linux x86 64-bit            | CentOS 6.10              | gcc 7.5                         |
-| Linux on ARM 64-bit         | CentOS 7                 | gcc 7.4                         |
+| Linux on ARM 64-bit         | CentOS 7                 | gcc 7.5                         |
 | Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 7.5                         |
 | Linux on IBM Z 64-bit       | RHEL 7.7                 | gcc 7.5                         |
 | Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2017    |


### PR DESCRIPTION
Cherry pick #557 - Remove support for Windows 8.1, Server 2012, but not R2
and #558 - Linux on ARM 64-bit uses gcc 7.5
for the 0.20.0 branch.