### PR TITLE
Updates to docs re inclusive language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,7 +275,7 @@ the staged draft of your documentation, visit the following URL, substituting &l
      
 ## Accepting contributions
 
-_(whitelisted users only)_
+_(approved users only)_
 
 Project committers are responsible for checking pull requests and merging changes.
 

--- a/docs/xtgc.md
+++ b/docs/xtgc.md
@@ -39,7 +39,7 @@ Provides garbage collection tracing options.
 
         -Xtgc:backtrace
 
-: Before a garbage collection, a single line is printed containing the name of the master thread for garbage collection, as well as the value of the `osThread` slot in the `J9VMThread` structure.
+: Before a garbage collection, a single line is printed containing the name of the main thread for garbage collection, as well as the value of the `osThread` slot in the `J9VMThread` structure.
 
 ### `compaction`
 


### PR DESCRIPTION
1x "whitelist" in `CONTRIBUTING.md` : ("whitelisted users" --> "approved users")
0x "blacklist"
1x "master" in `xtgc.md` : ("master thread" --> "main thread")
4x "slave" in tool_jdmpview.md in output example *not* changed until code changes
NB references to "master" in following link path not considered at present:
`https://github.com/eclipse/openj9/blob/master/doc/release-notes/...`
See https://github.com/eclipse/openj9/issues/10071

Signed-off-by: Peter Hayward <pmhayward@uk.ibm.com>