### PR TITLE
Remove sentence about default behaviour of shared classes

### DIFF
--- a/docs/xaot.md
+++ b/docs/xaot.md
@@ -42,7 +42,7 @@ Startup performance can be improved by using the shared AOT code to provide nati
 
 ## Default behavior
 
-The AOT compiler is enabled by default, but is only active for classes found in the shared classes cache (see [Class data sharing](shrc.md)). Class data sharing is enabled by default for bootstrap classes, but you can use the [`-Xshareclasses`](xshareclasses.md) option to modify the behavior of the shared classes cache.
+The AOT compiler is enabled by default, but is only active for classes that are found in the shared classes cache. See [Class data sharing](shrc.md) for information about the shared classes cache, how class sharing is enabled, and what options are available to modify class sharing behavior. 
 
 ## Syntax
 


### PR DESCRIPTION
https://github.com/eclipse/openj9-docs/issues/569

Removed sentence about default behaviour of shared classes as there's already a link to the "Class data sharing" topic, which describes that. Instead, expanded on the info the user can get from that topic. This way, the user can still easily get the shared classes info but the -Xaot topic won't need to be updated (possibly getting missed again and providing incorrect info) when/if the default shared classes behaviour changes in the future.

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>