### PR TITLE
Update JDK15 xlinux build env and update minimum support levels

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -75,16 +75,16 @@ OpenJDK 8 binaries are supported on the minimum operating system levels shown in
 
 | Linux&reg;                            |   x32  |  x64   | ppc64le    | Z31  | Z64 |
 |---------------------------------------|--------|--------|------------|------|------|
-| CentOS 6.9                            |   Y    |   Y    |     N      |   N  |  N   |
-| CentOS 7.4                            |   Y    |   Y    |     Y      |   N  |  N   |
-| Red Hat Enterprise Linux (RHEL) 6.9   |   Y    |   Y    |     N      |   Y  |  Y   |
-| RHEL 7.4                              |   Y    |   Y    |     Y      |   Y  |  Y   |
+| CentOS 6.10                           |   Y    |   Y    |     N      |   N  |  N   |
+| CentOS 7.6                            |   Y    |   Y    |     Y      |   N  |  N   |
+| Red Hat Enterprise Linux (RHEL) 6.10  |   Y    |   Y    |     N      |   N  |  N   |
+| RHEL 7.6                              |   Y    |   Y    |     Y      |   Y  |  Y   |
 | SUSE Linux Enterprise Server (SLES) 12|   Y    |   Y    |     Y      |   Y  |  Y   |
 | Ubuntu 16.04                          |   Y    |   Y    |     Y      |   N  |  Y   |
 | Ubuntu 18.04                          |   Y    |   Y    |     Y      |   N  |  Y   |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Not all of these distributions are tested, but Linux distributions that have a
-minimum glibc version 2.12 are expected to function without problems.
+minimum glibc version 2.12 (x) or 2.17 (others) are expected to function without problems.
 
 | Windows&reg;               |  x32   |  x64  |
 |----------------------------|--------|-------|
@@ -115,17 +115,17 @@ OpenJDK 11 binaries are supported on the minimum operating system levels shown i
 
 | Linux (**Note 1**)                    | AArch64 (**Note 2**)    | x64   |  ppc64le   | Z64  |
 |---------------------------------------|-------------------------|-------|------------|------|
-| CentOS 6.9                            |    N                    |  Y    |     N      |  N   |
-| CentOS 7.4                            |    Y                    |  Y    |     Y      |  N   |
-| Red Hat Enterprise Linux (RHEL) 6.9   |    N                    |  Y    |     N      |  Y   |
-| RHEL 7.4                              |    Y                    |  Y    |     Y      |  Y   |
+| CentOS 6.10                           |    N                    |  Y    |     N      |  N   |
+| CentOS 7.6                            |    Y                    |  Y    |     Y      |  N   |
+| Red Hat Enterprise Linux (RHEL) 6.10  |    N                    |  Y    |     N      |  N   |
+| RHEL 7.6                              |    Y                    |  Y    |     Y      |  Y   |
 | SUSE Linux Enterprise Server (SLES) 12|    N                    |  Y    |     Y      |  Y   |
 | Ubuntu 16.04                          |    Y                    |  Y    |     Y      |  Y   |
 | Ubuntu 18.04                          |    Y                    |  Y    |     Y      |  Y   |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Notes:**
 
-1. Not all of these distributions are tested, but Linux distributions that have a minimum glibc version 2.12 are expected to function without problems.
+1. Not all of these distributions are tested, but Linux distributions that have a minimum glibc version 2.12 (x) or 2.17 (others) are expected to function without problems.
 2. Only limited support for the 64-bit ARM architecture is currently available. For a list of known issues, see the [Release notes](https://github.com/eclipse/openj9/tree/master/doc/release-notes) for the latest version of Eclipse OpenJ9.
 
 | Windows                    |  x64   |
@@ -157,14 +157,14 @@ OpenJDK 15 binaries are supported on the minimum operating system levels shown i
 
 | Linux                                 |  x64   |  ppc64le   | Z64  |
 |---------------------------------------|--------|------------|------|
-| CentOS 7.4                            |   Y    |     Y      |  N   |
-| RHEL 7.4                              |   Y    |     Y      |  Y   |
+| CentOS 7.6                            |   Y    |     Y      |  N   |
+| RHEL 7.6                              |   Y    |     Y      |  Y   |
 | SUSE Linux Enterprise Server (SLES) 12|   Y    |     Y      |  Y   |
 | Ubuntu 16.04                          |   Y    |     Y      |  Y   |
 | Ubuntu 18.04                          |   Y    |     Y      |  Y   |
 
 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Not all of these distributions are tested, but Linux distributions that have a
-minimum glibc version 2.12 are expected to function without problems.
+minimum glibc version 2.17 are expected to function without problems.
 
 | Windows                    |  x64   |
 |----------------------------|--------|
@@ -196,7 +196,7 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 | Platform                                    | Operating system          |  Compiler                       |
 |---------------------------------------------|---------------------------|---------------------------------|
 | Linux x86 64-bit                            | CentOS 6.10               | gcc 7.5                         |
-| Linux on POWER&reg; LE 64-bit               | Ubuntu 16.04              | gcc 7.5                         |
+| Linux on POWER&reg; LE 64-bit               | CentOS 7.8                | gcc 7.5                         |
 | Linux on IBM Z&reg; 64-bit                  | RHEL 7.7                  | gcc 7.5                         |
 | Windows x86 32-bit                          | Windows Server 2012 R2    | Microsoft Visual Studio 2010 SP1|
 | Windows x86 64-bit                          | Windows Server 2012 R2    | Microsoft Visual Studio 2010 SP1|
@@ -209,7 +209,7 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 |-----------------------------|--------------------------|---------------------------------|
 | Linux x86 64-bit            | CentOS 6.10              | gcc 7.5                         |
 | Linux on ARM 64-bit         | CentOS 7                 | gcc 7.5                         |
-| Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 7.5                         |
+| Linux on POWER LE 64-bit    | CentOS 7.8               | gcc 7.5                         |
 | Linux on IBM Z 64-bit       | RHEL 7.7                 | gcc 7.5                         |
 | Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2017    |
 | macOS x86 64-bit            | macOS 10.13.5            | xcode/clang 9.4                 |
@@ -219,8 +219,8 @@ The project build and test OpenJDK with OpenJ9 on a number of platforms. The ope
 
 | Platform                    | Operating system         |  Compiler                       |
 |-----------------------------|--------------------------|---------------------------------|
-| Linux x86 64-bit            | CentOS 6.10              | gcc 7.5                         |
-| Linux on POWER LE 64-bit    | Ubuntu 16.04             | gcc 7.5                         |
+| Linux x86 64-bit            | CentOS 7.8               | gcc 7.5                         |
+| Linux on POWER LE 64-bit    | CentOS 7.8               | gcc 7.5                         |
 | Linux on IBM Z 64-bit       | RHEL 7.7                 | gcc 7.5                         |
 | Windows x86 64-bit          | Windows Server 2012 R2   | Microsoft Visual Studio 2017    |
 | macOS x86 64-bit            | macOS 10.13.5            | xcode/clang 9.4                 |


### PR DESCRIPTION
- glibc minimum 2.12 only applies to x. others have a minimum 2.17
- update RHEL/CentOS 6 minimum to 6.10
- update RHEL/CentOS 7 minimum to 7.6
- remove RHEL 6 support for Z
- fix build environment for P, it was changed some time back

Fixes #613