### PR TITLE
Improve the detail condition for container-related docs

### DIFF
--- a/docs/xms.md
+++ b/docs/xms.md
@@ -31,6 +31,8 @@ These Oracle&reg; HotSpot&trade; options set the initial/minimum Java&trade; hea
 
 - If you set `-Xms` &gt; `-Xmx`, the OpenJ9 VM fails with the message `-Xms too large for -Xmx`.
 - If you exceed the limit set by the `-Xmx` option, the OpenJ9 VM generates an `OutofMemoryError`.
+- If you set a value for `-Xms`, the [`-XX:InitialRAMPercentage`](xxinitialrampercentage.md) option is ignored.
+- If you set a value for `-Xmx`, the [`-XX:MaxRAMPercentage`](xxinitialrampercentage.md) option is ignored.
 
 If you are allocating the Java heap with large pages, see also [-Xlp](xlp.md) and
 [More effective heap usage using compressed references](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_compressed_refs.html).

--- a/docs/xxinitialrampercentage.md
+++ b/docs/xxinitialrampercentage.md
@@ -35,7 +35,8 @@ These Oracle HotSpot options can be used to specify the initial and maximum size
 
 : Where N is a value between 0 and 100, which can be of type "double". For example, 12.3456.
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you set a value for [`-Xms`](xms.md), these options are ignored.
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you set a value for [`-Xms`](xms.md), the `-XX:InitialRAMPercentage` option is ignored.
+If you set a value for [`-Xmx`](xms.md), the `-XX:MaxRAMPercentage` option is ignored.
 
 If your application is running in a container and you have specified [`-XX:+UseContainerSupport`](xxusecontainersupport.md), both the default heap size for containers, the `-XX:InitialRAMPercentage` option, and the `-XX:MaxRAMPercentage` option are based on the available container memory.
 

--- a/docs/xxusecontainersupport.md
+++ b/docs/xxusecontainersupport.md
@@ -62,6 +62,7 @@ When [`-XX:MaxRAMPercentage` / `-XX:InitialRAMPercentage`](xxinitialrampercentag
 
     -XX:+UseContainerSupport -XX:MaxRAMPercentage=80
 
-
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you set a value for [`-Xms`](xms.md), the `-XX:InitialRAMPercentage` option is ignored.
+If you set a value for [`-Xmx`](xms.md), the `-XX:MaxRAMPercentage` option is ignored.
 
 <!-- ==== END OF TOPIC ==== xxusecontainersupport.md ==== -->


### PR DESCRIPTION
 - The `-XX:InitialRAMPercentage` option is ignored, when -Xms is
specified.
 - The `-XX:MaxRAMPercentage` option is ignored, when -Xmx is specified.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>