### PR TITLE
The Default max heap size limit

### DIFF
--- a/docs/openj9_defaults.md
+++ b/docs/openj9_defaults.md
@@ -93,6 +93,10 @@ The default value of [`-Xmx`](xms.md) :
 
 - The value is 25% of the available memory with a maximum of 25 GB. However, where there is 2 GB or less of physical memory, the value set is 50% of available memory with a minimum value of 16 MB and a maximum value of 512 MB.
 
+- If the VM is running in a container **(Linux&reg; only)** and [UseContainerSupport](xxusecontainersupport.md) is enabled, The value is 75% of the Container memory limit with a maximum of 25GB. However, where there is less 1G of Container memory limit, the value set is 50% of Container memory limit; If Container memory limit is between 1GB and 2GB, the value set is Container memory limit - 512 MB.
+
+- The default value is capped at 25GB, which is the limit of heap size for 3-bit shift of [Compressed References](xcompressedrefs.md), in order to prevent silent switching to 4-bit shift [Compressed References](xcompressedrefs.md) with possible performance penalties. Using [`-Xmx`](xms.md) option can overwrite the 25GB limit.
+
 - ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) If you have set the [-XX:+OriginalJDK8HeapSizeCompatibilityMode](xxoriginaljdk8heapsizecompatibilitymode.md) option for compatibility with earlier releases, the value is half the available memory with a minimum of 16 MB and a maximum of 512 MB. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
 
 *Available memory* is defined as being the smallest of two values: The real or *physical* memory or the *RLIMIT_AS* value.

--- a/docs/xxusecontainersupport.md
+++ b/docs/xxusecontainersupport.md
@@ -50,6 +50,9 @@ The following table shows the values that are used when `-XX:+UseContainerSuppor
 | 1 GB - 2 GB                           | *&lt;size&gt;* - 512 MB |
 | Greater than 2 GB                     | 75% *&lt;size&gt;*      |
 
+
+The default heap size also limit to 25GB, which is the limit of heap size for 3-bit shift of [Compressed References](xcompressedrefs.md), in order to prevent silent switching to 4-bit shift [Compressed References](xcompressedrefs.md) with possible performance penalties. Using [`-Xmx`](xms.md) option or [`-XX:MaxRAMPercentage`](xxinitialrampercentage.md) can overwrite the 25GB limit.
+
 The default heap size for containers takes affect only when the following conditions are met:
 
 1. The application is running in a container environment.


### PR DESCRIPTION
	- explain the default max heap size limit to 25GB.
        - options to overwrite the limit.

Closes #626
Closes https://github.com/eclipse/openj9/issues/10200