### PR TITLE
Update the jdk 11 iframe to use a name which search.js expects

### DIFF
--- a/docs/api-jdk11.md
+++ b/docs/api-jdk11.md
@@ -25,6 +25,6 @@
 # OpenJ9 JDK 11 API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk11/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="../api/jdk11/index.html?view=embed" title="API viewer" name="classFrame" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api/jdk11/search.js
+++ b/docs/api/jdk11/search.js
@@ -313,10 +313,12 @@ $(function() {
                     }
                 } else if (ui.item.category === catSearchTags) {
                     url += ui.item.u;
+                }
+                if (top !== window) {
+                    parent.classFrame.location = pathtoroot + url;
+                } else {
+                    window.location.href = pathtoroot + url;
                 } 
-                
-                window.location.href = pathtoroot + url;
-
                 $("#search").focus();
             }
         }


### PR DESCRIPTION
The search.js script expects an iframe with a name of "classFrame" otherwise the search silently (to the user) fails.