### PR TITLE
Update documentation for PortableSharedCache

### DIFF
--- a/docs/version0.23.md
+++ b/docs/version0.23.md
@@ -1,0 +1,48 @@
+<!--
+* Copyright (c) 2017, 2020 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# What's new in version 0.23.0
+
+The following new features and notable changes since v 0.22.0 are included in this release:
+
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.20.0 supports OpenJDK 8, 11, and 14. Binaries are available from the AdoptOpenJDK community at the following links:
+
+- [OpenJDK version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK version 14](https://adoptopenjdk.net/archive.html?variant=openjdk14&jvmVariant=openj9)
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+
+### `-XX:[+|-]PortableSharedCache` option behavior update
+The `-XX:[+|-]PortableSharedCache` option is updated to improve the portability of AOT-compiled code further. This update allows AOT-compiled code to be portable across OpenJ9 VMs that use compressed references and have a heap size of 1 MB to 28 GB when this option is enabled. This option might introduce a small (1-2%) steady-state throughput penalty when compressed references are used and the heap size is between 1 MB and 3 GB. See [`-XX:[+|-]PortableSharedCache`](xxportablesharedcache.md) for more details about this option.
+
+
+<!-- ==== END OF TOPIC ==== version0.23.md ==== -->

--- a/docs/xxportablesharedcache.md
+++ b/docs/xxportablesharedcache.md
@@ -24,11 +24,17 @@
 
 # -XX:\[+|-\]PortableSharedCache
 
-**(x86 only)**
+**(x86 platforms only)**
 
-Use this command line option to choose whether AOT code should be generated using an older processor (Intel&reg; Sandybridge) feature set on the x86 platform, which therefore allows the AOT code to be portable; it can be run on any Intel Sandybridge or newer processor without you having to choose a machine with a suitably old processor for generating the AOT code.
+Use this command line option to choose whether AOT-compiled code should be portable.
 
-This feature is particularly relevant for packaging a shared classes cache into a container image (for example, applications deployed on the cloud in the form of Docker containers) because the processor on which the container image is built is likely to be different from the processor on which the container is deployed. 
+This option, when enabled, increases the portability of AOT-compiled code, in the following ways:
+- The code is generated based on a particular set of processor features (present in the Intel® Sandy Bridge microarchitecture) that ensures the AOT-compiled code to be portable across any Intel Sandybridge or newer processor.
+- The code is generated to be portable across OpenJ9 VMs that use compressed references and have a heap size of 1 MB to 28 GB (previously, AOT-compiled code could not be shared between VMs that use compressed references and that have different heap sizes). This feature might introduce a small (1-2%) steady-state throughput penalty when compressed references are used and the heap size is between 1 MB and 3 GB.
+
+This feature is particularly relevant for packaging a shared classes cache into a container image (for example, applications deployed on the cloud in the form of Docker containers) due to the following reasons:
+- The processor on which the container image is built is likely to be different from the processor on which the container is deployed. 
+- In a multi-layered container image where the shared classes cache is multi-layered as well, the AOT-compiled code in shared classes cache will likely come from multiple OpenJ9 VMs with different heap size requirements.
 
 ## Syntax
 


### PR DESCRIPTION
Introduced additional changes to the Portable Shared Cache feature (-XX:[+|-]PortableSharedCache) which eliminates the AOT portability issues of Compressed Reference OpenJ9 builds with heap sizes from 0GB to 28GB. Previously compressed reference JVMs with different heap sizes cannot share AOT compiled code with each other. When Portable Shared Cache is enabled (either via -XX:[+|-]PortableSharedCache or by default in containers), Compressed Reference OpenJ9 builds with heap size in the range of 0GB to 28GB will be able to share AOT complied code with each other. However there will be a slight steady-state throughput penalty of 1-2% when using this option now compared to before.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>