### PR TITLE
jextract checks build ids, change in behavior

### DIFF
--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -30,14 +30,21 @@ On some operating systems, copies of executable files and libraries are required
 
 ## Syntax
 
-        jextract <core file name> [<zip_file>]
+        jextract [-r] <core file name> [<zip_file>]
 
 where:
 
+- `-r` forces the `jextract` utility to proceed when the system dump is created from an SDK with a different build ID. See **Restriction**.
 - `<core file name>` is the name of the system dump.
 - `<zip_file>` is the name you want to give to the processed file. If you do not specify a name, output is written to `<core file name>.zip` by default. The output is written to the same directory as the core file.
 
-: <i class="fa fa-exclamation-triangle"></i> **Restriction: ** You must run `jextract` on the same system that produced the system dump in order to collect the correct executables and libraries referenced in the system dump. You should also run `jextract` using the same VM level, to avoid any problems.
+<i class="fa fa-exclamation-triangle"></i> **Restriction:** You should run `jextract` on the same system that produced the system dump in order to collect the correct executables and libraries referenced in the system dump. You should also run `jextract` using the same VM level, to avoid any problems. From Eclipse OpenJ9 V0.24.0, the utility always checks that the build ID of the SDK that created the dump file matches the `jextract` build ID. Where these IDs do not match, the following exception is thrown:
+
+```  
+J9RAS.buildID is incorrect (found XXX, expecting YYY). This version of jextract is incompatible with this dump (use '-r' option to relax this check).
+```
+
+To continue, despite the mismatch, use the `-r` option.
 
 ## See also
 

--- a/docs/version0.23.md
+++ b/docs/version0.23.md
@@ -32,6 +32,7 @@ The following new features and notable changes since v 0.22.0 are included in th
 - [`-XX:[+|-]IdleTuningCompactOnIdle` option now inactive](#-xx-idletuningcompactonidle-option-now-inactive)
 - [Support for OpenJDK HotSpot options](#support-for-openjdk-hotspot-options)
 
+
 ## Features and changes
 
 ### Binaries and supported environments
@@ -58,10 +59,8 @@ For compatibility, the following OpenJDK HotSpot options are now supported by Op
 
 - [`-XX:[+|-]AlwaysPreTouch`](xxalwayspretouch.md)
 
-
 ## Full release information
 
 To see a complete list of changes between Eclipse OpenJ9 v 0.22.0 and v 0.23.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.23/0.23.md).
 
 <!-- ==== END OF TOPIC ==== version0.23.md ==== -->
-


### PR DESCRIPTION
Build ID of jextract utility checked against SDK build ID in dump.
If they don't match, an exception is thrown. New option allows override.

Closes: #649

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>