### PR TITLE
Align GC policy terminology and structure

### DIFF
--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -59,13 +59,13 @@ Options that change the behavior of the Garbage Collector (GC).
 
 : This option supports pause-less garbage collection mode when you use the Generational Concurrent ([`gencon`](xgcpolicy.md#gencon)) garbage collection policy (the default policy).
 
-    If you set this option, the VM attempts to reduce GC pause times for response-time sensitive, large-heap applications.
+    If you set this option, the VM attempts to reduce GC pause times for response-time sensitive, large-heap applications. This mode can be enabled with hardware-based support (Linux on IBM Z&reg; and z/OS&reg;) and software-based support (64-bit: Linux on (x86-64, POWER&reg;, IBM Z&reg;) AIX&reg;, macOS&reg;, and z/OS).
 
-    <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note: Linux on Z and z/OS**
+    <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note: Linux on IBM Z and z/OS**
 
-    This option is supported by all generations of IBM Z&reg; hardware to enable pause-less GC with two modes of operation: hardware-based and software-based operations. IBM z13&trade; and earlier hardware operates in software-based pause-less GC mode; and IBM z14&trade; and later hardware (with supported software) operates in hardware-based mode.
+    This option is supported by all generations of IBM Z hardware to enable pause-less GC with two modes of operation: hardware-based and software-based operations. IBM z13&trade; and earlier hardware operates in software-based pause-less GC mode; IBM z14&trade; and later hardware (with supported software) operates in hardware-based mode.
 
-    Hardware-based pause-less GC is supported on IBM z14&trade; and later hardware running the following software:
+    Hardware-based pause-less GC is supported on IBM z14 and later hardware running the following software:
 
     Operating systems:
 

--- a/docs/xgcpolicy.md
+++ b/docs/xgcpolicy.md
@@ -25,7 +25,7 @@
 # -Xgcpolicy
 
 
-Controls the behavior of the garbage collector by specifying different garbage collection policies.
+Controls which Garbage Collection (GC) policy is used for your Java&trade; application.
 
 ## Syntax
 
@@ -42,32 +42,31 @@ Controls the behavior of the garbage collector by specifying different garbage c
 | [`optthruput`](#optthruput)                                                  |         |
 | [`nogc`](#nogc)                                                              |         |
 
-
-Specify the garbage collection policy that you want the OpenJ9 VM to use:
+For a detailed description of the policies, when to use them, and how they work, see [Garbage Collection policies](gc.md). The following GC policies are available:
 
 ### `gencon`
 
         -Xgcpolicy:gencon
 
-: The generational concurrent policy (default) uses a concurrent mark phase combined with generational garbage collection to help minimize the time that is spent in any garbage collection pause. This policy is particularly useful for applications with many short-lived objects, such as transactional applications. Pause times can be significantly shorter than with the `optthruput` policy, while still producing good throughput. Heap fragmentation is also reduced.
+: The generational concurrent policy (default) requires a heap that is divided into two main areas (*nursery* and *tenure*) to manage two generation groups (*new* and *older*). The policy uses a global GC cycle of concurrent *mark-sweep* operations, optionally followed by *compact* operations. The policy also uses a partial GC cycle to run *scavenge* operations on the *nursery* area. The partial cycle helps reduce the frequency and duration of the global GC cycle. Note that *scavenge* is a *stop-the-world* operation, unless `-Xgcpolicy:gencon` is specified with the [`-Xgc:concurrentScavenge`](xgc.md#concurrentscavenge) option.
 
-: To learn more about this policy and how it works, see [Garbage collection: 'gencon' policy](gc.md#gencon-policy-default).
+: To learn more about this policy, when to use it, and how it works, see [Garbage collection: `gencon` policy](gc.md#gencon-policy-default).
 
 
 ### `balanced`
 
         -Xgcpolicy:balanced
 
-: The balanced policy policy uses mark, sweep, compact and generational style garbage collection. The concurrent mark phase is disabled; concurrent garbage collection technology is used, but not in the way that concurrent mark is implemented for other policies. The `balanced` policy uses a region-based layout for the Java&trade; heap. These regions are individually managed to reduce the maximum pause time on large heaps and increase the efficiency of garbage collection. The policy tries to avoid global collections by matching object allocation and survival rates.
+: The Balanced policy requires a multi-region heap to manage multiple generations of objects. The policy uses a global GC cycle that involves an incremental concurrent *mark* operation (global mark phase), followed by *stop-the-world* (STW) *sweep* operation. The policy also uses a partial GC cycle to run *copy forward* or *mark-compact* operations. Regions are individually managed to reduce the maximum pause time on large heaps and increase the efficiency of garbage collection. The policy tries to avoid global collections by matching object allocation and survival rates. With the `balanced` policy, the global mark and partial GC cycles interleave. The global STW *sweep* operation runs within the same GC increment as the first partial GC cycle that follows the global mark phase.
 
-: If you have problems with application pause times that are caused by global garbage collections, particularly compactions, this policy might improve application performance. If you are using large systems that have Non-Uniform Memory Architecture (NUMA) characteristics (x86 and POWER&trade; platforms only), the balanced policy might further improve application throughput.
+: The `balanced` policy also exploits large systems that have Non-Uniform Memory Architecture (NUMA) characteristics (x86 and POWER&trade; platforms only), which might further improve application throughput.
 
-: <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you are using the balanced GC policy in a Docker container that uses the default `seccomp` Docker profile, you must start the container with `--security-opt seccomp=unconfined` to exploit NUMA characteristics. These options are not required if you are running in Kubernetes, because `unconfined` is set by default (see [Seccomp]( https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp)).
+: <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** If you are using this GC policy in a Docker container that uses the default `seccomp` Docker profile, you must start the container with `--security-opt seccomp=unconfined` to exploit NUMA characteristics. These options are not required if you are running in Kubernetes, because `unconfined` is set by default (see [Seccomp]( https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp)).
 
-: To learn more about this policy and how it works, see [Garbage collection: 'balanced' policy](gc.md#balanced-policy).
+: To learn more about this policy, how it works, and when to use it, see [Garbage collection: `balanced` policy](gc.md#balanced-policy).
 
 
-#### Defaults and options
+#### `balanced` defaults and options
 
 The initial heap size is *Xmx/1024*, rounded down to the nearest power of 2, where *Xmx* is the maximum heap size available. You can override this value by specifying the `-Xms` option on the command line.
 
@@ -110,10 +109,10 @@ The behavior of the following options is different when specified with `-Xgcpoli
 : Disables internal compaction heuristics in Global GC cycles.
 
 [`-Xcompactexplicitgc`](xcompactexplicitgc.md) (default)
-: Forces compaction in Explicit Global GC cycles, such as those invoked by `System.gc()`. Compaction in implicit Global GC remains optional, triggered by internal heuristics.
+: Forces compaction in explicit Global GC cycles, such as those invoked by `System.gc()`. Compaction in implicit Global GC remains optional, triggered by internal heuristics.
 
 [`-Xnocompactexplicitgc`](xcompactexplicitgc.md)
-: Disables compaction in Explicit Global GC cycles. Compaction in implicit Global GC remains optional, triggered by internal heuristics.
+: Disables compaction in explicit Global GC cycles. Compaction in implicit Global GC remains optional, triggered by internal heuristics.
 
 The following options are ignored when specified with `-Xgcpolicy:balanced`:
 
@@ -141,66 +140,61 @@ The following options are ignored when specified with `-Xgcpolicy:balanced`:
 
         -Xgcpolicy:optavgpause
 
-: The "optimize for pause time" policy uses concurrent mark and concurrent sweep phases. Pause times are shorter than with `optthruput`, but application throughput is reduced because some garbage collection work is taking place in the context of mutator (application) threads, and GC frequency is increased.
+: The *optimize for pause time* policy requires a *flat* heap and uses a global GC cycle to run concurrent *mark-sweep* operations, optionally followed by *compact* operations. Pause times are shorter than with `optthruput`, but application throughput is reduced. The impact on throughput occurs because some garbage collection work is taking place in the context of mutator (application) threads, and because GC frequency is increased.
 
-    Consider using this policy if you have a large heap size (available on 64-bit platforms), because this policy limits the effect of increasing heap size on the length of the garbage collection pause. However, if your application uses many short-lived objects, the `gencon` policy might produce better performance.
-
-    For more information about this policy, see [Garbage collection: 'optavgpause' policy](gc.md#optavgpause-policy).
+    To learn more about this policy and when to use it, see [Garbage collection: `optavgpause` policy](gc.md#optavgpause-policy).
 
 
 ### `optthruput`
 
         -Xgcpolicy:optthruput
 
-: The "optimize for throughput" policy disables the concurrent mark phase. The application stops during global garbage collection, so long pauses can occur. 
+: The *optimize for throughput* policy requires a *flat* heap and uses a global GC cycle to run *mark-sweep* operations, optionally followed by *compact* operations. Because the application stops during a global GC cycle, long pauses can occur.
 
-    This configuration is typically used for large-heap applications when high application throughput, rather than short garbage collection pauses, is the main performance goal. If your application cannot tolerate long garbage collection pauses, consider using another policy, such as `gencon`.
-
-    For more information about this policy, see [Garbage collection: 'optavgpause' policy](gc.md#optavgpause-policy).
+    To learn more about this policy, how it works, and when to use it, see [Garbage collection: `optthruput` policy](gc.md#optthruput-policy).
 
 
 ### `metronome` (AIX, Linux x86 only)
 
         -Xgcpolicy:metronome
 
-: The metronome policy is an incremental, deterministic garbage collector with short pause times. Applications that are dependent on precise response times can take advantage of this technology by avoiding potentially long delays from garbage collection activity. The metronome policy is supported on specific hardware and operating system configurations.
+: The metronome policy is an incremental, deterministic garbage collector with short pause times. Applications that are dependent on precise response times can take advantage of this technology by avoiding potentially long delays from GC activity. The `metronome` policy is supported on specific hardware and operating system configurations.
 
-    For more information about this policy, see [Garbage collection: 'metronome' policy](gc.md#metronome-policy).
-<!-- [Using the Metronome Garbage Collector](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_mgc.html). -->
+    To learn more about this policy, how it works, and when to use it, see [Garbage collection: `metronome` policy](gc.md#metronome-policy).
 
-#### Defaults and options
+#### `metronome` defaults and options
 
 `-Xgc:synchronousGCOnOOM | -Xgc:nosynchronousGCOnOOM`
-: One occasion when garbage collection occurs is when the heap runs out of memory. If there is no more free space in the heap, using `-Xgc:synchronousGCOnOOM` stops your application while garbage collection removes unused objects. If free space runs out again, consider decreasing the target utilization to allow garbage collection more time to complete. Setting `-Xgc:nosynchronousGCOnOOM` implies that when heap memory is full your application stops and issues an out-of-memory message. The default is `-Xgc:synchronousGCOnOOM`.
+: GC cycles can occur when the Java heap runs out of memory. If there is no more free space in the heap, using `-Xgc:synchronousGCOnOOM` stops your application while GC operations remove unused objects. If free space runs out again, consider decreasing the target utilization to allow GC operations more time to complete. Setting `-Xgc:nosynchronousGCOnOOM` implies that when heap memory is full your application stops and issues an *out-of-memory* message. The default is `-Xgc:synchronousGCOnOOM`.
 
-`-Xclassgc | -Xnoclassgc | -Xalwaysclassgc` 
+`-Xclassgc | -Xnoclassgc | -Xalwaysclassgc`
 
-: [`-Xnoclassgc`](xclassgc.md) disables class garbage collection. This option switches off garbage collection of storage associated with Java classes that are no longer being used by the OpenJ9 VM. The default behavior is [`-Xclassgc`](xclassgc.md), which heuristically decides which GC cycle will attempt to unload classes.
+: [`-Xnoclassgc`](xclassgc.md) disables class garbage collection. This option switches off the collection of storage associated with Java classes that are no longer being used by the OpenJ9 VM. The default behavior is [`-Xclassgc`](xclassgc.md), which heuristically decides which GC cycle will attempt to unload classes.
 
-: <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Disabling class garbage collection is not recommended as this causes unlimited native memory growth, leading to out-of-memory errors.
+: <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** Disabling class GC is not recommended as this causes unlimited native memory growth, leading to *out-of-memory* errors.
 
-: [`-Xalwaysclassgc`](xalwaysclassgc.md) always performs dynamic class unloading checks during global garbage collection.
+: [`-Xalwaysclassgc`](xalwaysclassgc.md) always performs dynamic class unloading checks during global GC cycles.
 
 `-Xgc:targetPauseTime=N`
-: Sets the garbage collection pause time, where N is the time in milliseconds. When this option is specified, the GC operates with pauses that do not exceed the value specified. If this option is not specified the default pause time is set to 3 milliseconds. For example, running with `-Xgc:targetPauseTime=20` causes the GC to pause for no longer than 20 milliseconds during GC operations.
+: Sets the GC pause time, where N is the time in milliseconds. When this option is specified, the GC operates with pauses that do not exceed the value specified. If this option is not specified the default pause time is set to 3 milliseconds. For example, running with `-Xgc:targetPauseTime=20` causes the GC to pause for no longer than 20 milliseconds during GC operations.
 
 `-Xgc:targetUtilization=N`
-: Sets the application utilization to `N%`; the Garbage Collector attempts to use at most (100-N)% of each time interval. Reasonable values are in the range of 50-80%. Applications with low allocation rates might be able to run at 90%. The default is 70%.
+: Sets the application utilization to `N%`; the GC attempts to use at most (100-N)% of each time interval. Reasonable values are in the range of 50-80%. Applications with low allocation rates might be able to run at 90%. The default is 70%.
 
-    This example shows the maximum size of the heap memory is 30 MB. The garbage collector attempts to use 25% of each time interval because the target utilization for the application is 75%.
+    In the following example, the maximum size of the heap is set to 30 MB. The GC attempts to use 25% of each time interval because the target utilization for the application is set to 75%.
 
         java -Xgcpolicy:metronome -Xmx30m -Xgc:targetUtilization=75 Test
 
 `-Xgc:threads=N`
-: Specifies the number of GC threads to run. The default is the number of processor cores available to the process. The maximum value you can specify is the number of processors available to the operating system.
+: Specifies the number of GC threads to run. The default is the number of processor cores available to the process. The maximum value that you can specify is the number of processors available to the operating system.
 
 `-Xgc:verboseGCCycleTime=N`
-: N is the time in milliseconds that the summary information should be dumped.
+: N is the time in milliseconds that the summary information should be logged.
 
-    <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The cycle time does not mean that the summary information is dumped precisely at that time, but when the last garbage collection event that meets this time criterion passes.
+    <i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The cycle time does not mean that the summary information is logged precisely at that time, but when the last GC event that meets this time criterion passes.
 
 `-Xmx<size>`
-: Specifies the Java heap size. Unlike other garbage collection strategies, the real-time Metronome GC does not support heap expansion. There is not an initial or maximum heap size option. You can specify only the maximum heap size.
+: Specifies the Java heap size. Unlike other GC strategies, the `metronome` policy does not support heap expansion. You can specify only the maximum heap size, not an initial heap size (`-Xms`).
 
 
 ### `nogc`
@@ -209,14 +203,12 @@ The following options are ignored when specified with `-Xgcpolicy:balanced`:
 
 : This policy handles only memory allocation and heap expansion, but doesn't reclaim any memory. If the available Java heap becomes exhausted, an `OutOfMemoryError` exception is triggered and the VM stops.
 
-    Because there is no GC pause and most overheads on allocations are eliminated, the impact on runtime performance is minimized. This policy therefore provides benefits for "garbage-free" applications.
-
     You should be especially careful when using any of the following techniques with `nogc` because memory is never released under this policy:  
     - Finalization  
     - Direct memory access  
     - Weak, soft, and phantom references
 
-: To learn when to use this policy, see [Garbage collection: 'nogc' policy](gc.md#nogc-policy).
+: To learn when to use this policy, see [Garbage collection: `nogc` policy](gc.md#nogc-policy).
 
 This policy can also be enabled with the [`-XX:+UseNoGC`](xxusenogc.md) option.
 


### PR DESCRIPTION
- Apply agreed terminology changes to all policies
- Make structure consistent across areas
- Move "when to use" information from xgcpolicy option to main topic

Signed-off-by: SueChaplain <sue_chaplain@uk.ibm.com>