### PR TITLE
Expand note about information that may not be in core files

### DIFF
--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -39,7 +39,7 @@ The dump viewer is useful for diagnosing `OutOfMemoryError` exceptions in Java&t
 `jdmpview [-J<vm option>] (-core <core file> | -zip <zip file>) [-notemp]`
 
 
-|          Input option   |  Explanation                                                                                           |
+| Input option            | Explanation                                                                                            |
 |-------------------------|--------------------------------------------------------------------------------------------------------|
 | `-core <core file>`     | Specifies a dump file.                                                                                 |
 | `-zip <zip file>`       | Specifies a compressed file containing the core file (produced by the [dump extractor (`jextract`)](tool_jextract.md) tool on AIX&reg;, Linux&reg;, and macOS&reg; systems). |
@@ -47,15 +47,19 @@ The dump viewer is useful for diagnosing `OutOfMemoryError` exceptions in Java&t
 | `-J-Dcom.ibm.j9ddr.path.mapping=<mappings>` | The variable `<mappings>` is a list of native library mappings of the form `old-path=new-path`, using the usual path separator (a semi-colon (';') on Windows, and a colon (':') on other platforms). |
 | `-J-Dcom.ibm.j9ddr.library.path=<path>` | The variable `<path>` is a list of paths to search for native libraries, using the usual path separator (a semi-colon (';') on Windows, and a colon (':') on other platforms). |
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The `-core` option can be used with the `-zip` option to specify the core file in the compressed file. Without these options, `jdmpview` shows multiple contexts, one for each source file that it identified in the compressed file.
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** The `-core` option can be used with the `-zip` option to specify the core file in the compressed file. With these options, `jdmpview` shows multiple contexts, one for each source file that it identified in the compressed file.
 
-<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** On AIX and Linux, some `jdmpview` commands need to locate the native libraries that are referenced by the core. For example, commands that relate to callsites. First, check the list of native libraries by running `jdmpview` on a core with the `info mod` parameter. If the libraries are not in the original locations, ensure that `jdmpview` can locate them by specifying the path mapping (`-J-Dcom.ibm.j9ddr.path.mapping=<mappings>`) and library path (`-J-Dcom.ibm.j9ddr.library.path=<path>`) options specified on the `jdmpview` command line.  
+<i class="fa fa-pencil-square-o" aria-hidden="true"></i> **Note:** On AIX and Linux, some `jdmpview` commands need to locate the executable and the native libraries that are referenced by the core. For example, commands that relate to call-sites. Because a common scenario involves using `jdmpview` to examine core files that originate on different systems, even if the executable and the libraries are in their original locations, `jdmpview` may not consider them. First, check the executable and the list of native libraries by running `jdmpview` on a core with the `info mod` command.
+
+One way to assist `jdmpview` to locate those files is by specifying on command line one or both of the path mapping (`-J-Dcom.ibm.j9ddr.path.mapping=<mappings>`) and library path (`-J-Dcom.ibm.j9ddr.library.path=<path>`) options.
+
+Alternatively, on the system where the core file was produced, you can use `jextract` to collect all the relevant files into a single zip archive. That archive can be unpacked, possibly on another system, into a new, empty directory. Running `jdmpview` in that new directory (where the core file will be located) should allow it to find all the data it needs, including information that may not be included in the core file itself (e.g. symbols or sections). When using an archive produced by `jextract`, setting the path or library mapping system properties should not be necessary.
 
 On z/OS&reg;, you can copy the dump to an HFS file and supply that as input to `jdmpview`, or you can supply a fully qualified MVS&trade; data set name. For example:
 
 ```
 > jdmpview -core USER1.JVM.TDUMP.SSHD6.D070430.T092211
-DTFJView version 4.28.3, using DTFJ version 1.11.28004
+DTFJView version 4.29.5, using DTFJ version 1.12.29003
 Loading image from DTFJ...
 ```
 
@@ -557,12 +561,12 @@ If a class name is passed to info class, the following information is shown abou
 
 : Passes the number of items to display and the unit size, as listed in the following table, to the sub-command. For example, `x/12bd`.
 
-    |Abbreviation	| Unit       | Size    |
+    |Abbreviation | Unit       | Size    |
     |-------------|------------|---------|
-    |b	          | Byte       | 8-bit   |
-    |h            |	Half word  | 16-bit  |
-    |w            | Word       |	32-bit |
-    |g	          | Giant word | 64-bit  |
+    |b            | Byte       | 8-bit   |
+    |h            | Half word  | 16-bit  |
+    |w            | Word       | 32-bit  |
+    |g            | Giant word | 64-bit  |
 
     This command is similar to the use of the `x/` command in gdb, including the use of defaults.
 
@@ -602,7 +606,7 @@ User input is prefaced by a greater than symbol (>).
 
 ```
     test@madras:~/test> sdk/bin/jdmpview -core core.20121116.154147.16838.0001.dmp
-    DTFJView version 4.27.57, using DTFJ version 1.10.27022
+    DTFJView version 4.29.5, using DTFJ version 1.12.29003
     Loading image from DTFJ...
 
     For a list of commands, type "help"; for how to use "help", type "help help"


### PR DESCRIPTION
* note that `jextract` can make more information available to `jdmpview`
* update sample `jdmpview` version banners

Fixes #714.