### PR TITLE
Use absolute paths in footer links

### DIFF
--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -34,9 +34,9 @@
       <div class="above-line-links">
         <div class="column">
           <h3 >Docs</h3>
-          <span class="footer-link"><a href="../openj9_newuser/" >New to OpenJ9?</a></span>
-          <span class="footer-link"><a href="../introduction/">Getting started</a></span>
-          <span class="footer-link"><a href="../cmdline_specifying/">Command-line options</a></span>
+          <span class="footer-link"><a href="/openj9/docs/openj9_newuser/" >New to OpenJ9?</a></span>
+          <span class="footer-link"><a href="/openj9/docs/introduction/">Getting started</a></span>
+          <span class="footer-link"><a href="/openj9/docs/cmdline_specifying/">Command-line options</a></span>
         </div>
 
         <div class="column">


### PR DESCRIPTION
The footer is included in multiple pages at differing depths in the tree, so absolute paths are required.