### PR TITLE
Add HW acceleration and AIX default zlib changes

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -133,6 +133,10 @@ GPU processing is supported only on Linux little-endian systems, such as x86-64 
 
 Special consideration is needed when using the WDDM driver model for GPUs on Windows. Using the WDDM driver model means the GPU is also used as a display device and as such is subject to the [Timeout Detection and Recovery (TDR) mechanism](https://docs.microsoft.com/en-us/windows-hardware/drivers/display/timeout-detection-and-recovery) of Windows. If you are running demanding GPU workloads, you should increase the timeout from the default 2 seconds. More detail may be found in [NVIDIA's Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#driver-model).
 
+### Hardware acceleration
+
+OpenJ9 on AIX&reg; uses the hardware-accelerated `zlibNX` library when available. `zlibNX` is an enhanced version of the `zlib` compression library that supports hardware-accelerated data compression and decompression by using the Nest accelerators (NX) co-processor, available in the IBM POWER9&reg; or newer processors. The library can be installed on AIX&reg; 7.2 with Technology Level 4 Expansion Pack and later. OpenJ9 in AIX&reg; systems with the NX co-processor enabled and `zlibNX` installed will make use of the library. To learn more about `zlibNX`, see [Data compression by using the zlibNX library](https://www.ibm.com/support/knowledgecenter/ssw_aix_72/performance/zlibNX.html).
+
 ## Runtime options
 
 Runtime options are specified on the command line and include system properties, standard options, nonstandard (**-X**) options, and **-XX** options. For a detailed list of runtime options, see [OpenJ9 command-line options](cmdline_specifying.md)

--- a/docs/version0.25.md
+++ b/docs/version0.25.md
@@ -29,6 +29,7 @@ The following new features and notable changes since v 0.24.0 are included in th
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies to Java 16 plus](cr/java16plus.png) [New JDK 16 features](#new-jdk-16-features)
 - ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) [Support for the `-verbose:module` option](#support-for-the-verbosemodule-option)
+- [Change the default `zlib` library on AIX&reg;](#change-the-default-zlib-library-on-aix)
 
 
 ## Features and changes
@@ -82,6 +83,11 @@ WARNING: All illegal access operations will be denied in a future release
 
 The `-verbose:module` option is now supported for Java 11 and later releases. This option writes information to `stderr` for each module that is loaded and unloaded.
 
+### Change the default `zlib` library on AIX&reg;
+
+OpenJ9 for AIX&reg; uses the system `zlib` library by default instead of a bundled copy.
+
+OpenJ9 on AIX&reg; systems uses the hardware-accelerated `zlibNX` if the Nest accelerators (NX) co-processor is enabled and the library is installed. To learn more about hardware acceleration and the `zlibNX` library see [Hardware acceleration](introduction.md#hardware-acceleration).
 
 ## Full release information
 


### PR DESCRIPTION
* Hardware acceleration section with the use of `zlibNX`
* Release notes addition of the default `zlib` changes on AIX

Changes: eclipse/openj9#11624
Closes: #722 

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>