### PR TITLE
Editorial changes to 0.25.0 updates

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -50,6 +50,7 @@ You can use the following command-line options in OpenJ9, just as you did in Hot
 | [`-XX:ConcGCThreads`](xxconcgcthreads.md)                        | Configures the number of GC mutator background threads.                                                                                      |
 | [`-XX:[+|-]AlwaysPreTouch`](xxalwayspretouch.md)                 | Enables/disables committing of memory during initial heap inflation or heap expansion.                                                          |
 | [`-XX:[+|-]CompactStrings`](xxcompactstrings.md)                 | Enables/disables `String` compression                                                                                                        |
+| ![Start of content that applies to Java 16 plus](cr/java16plus.png) [`-XX:DiagnoseSyncOnValueBasedClasses=<number>`](xxdiagnosesynconvaluebasedclasses.md) | Configure warnings for value-based classes |
 | [`-XX:[+|-]DisableExplicitGC`](xxdisableexplicitgc.md)           | Enables/disables explicit `System.gc()` calls. (Alias for [`-Xdisableexplicitgc` / `-Xenableexplicitgc`](xenableexplicitgc.md))                       |
 | [`-XX:[+|-]ExitOnOutOfMemoryError`](xxexitonoutofmemoryerror.md) | Triggers VM shutdown on out-of-memory conditions.                                                                                            |
 | [`-XX:[+|-]HeapDumpOnOutOfMemory`](xxheapdumponoutofmemory.md)   | Enables/disables dumps on out-of-memory conditions.                                                                                          |

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -135,7 +135,7 @@ Special consideration is needed when using the WDDM driver model for GPUs on Win
 
 ### Hardware acceleration
 
-OpenJ9 on AIX&reg; uses the hardware-accelerated `zlibNX` library when available. `zlibNX` is an enhanced version of the `zlib` compression library that supports hardware-accelerated data compression and decompression by using the Nest accelerators (NX) co-processor, available in the IBM POWER9&reg; or newer processors. The library can be installed on AIX&reg; 7.2 with Technology Level 4 Expansion Pack and later. OpenJ9 in AIX&reg; systems with the NX co-processor enabled and `zlibNX` installed will make use of the library. To learn more about `zlibNX`, see [Data compression by using the zlibNX library](https://www.ibm.com/support/knowledgecenter/ssw_aix_72/performance/zlibNX.html).
+On AIX&reg; systems that contain the Nest accelerator (NX) co-processor, OpenJ9 can take advantage of the `zlibNX` library. This library is an enhanced version of the `zlib` compression library that supports hardware-accelerated data compression and decompression. The `zlibNX` library is supported on AIX version 7.2 TL4 and later and must be installed on the system. The Nest accelerator (NX) co-processor is available on IBM POWER9&reg; systems. To learn more about `zlibNX`, see [Data compression by using the zlibNX library](https://www.ibm.com/support/knowledgecenter/ssw_aix_72/performance/zlibNX.html).
 
 ## Runtime options
 

--- a/docs/version0.25.md
+++ b/docs/version0.25.md
@@ -29,7 +29,7 @@ The following new features and notable changes since v 0.24.0 are included in th
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies to Java 16 plus](cr/java16plus.png) [New JDK 16 features](#new-jdk-16-features)
 - ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) [Support for the `-verbose:module` option](#support-for-the-verbosemodule-option)
-- [Change the default `zlib` library on AIX&reg;](#change-the-default-zlib-library-on-aix)
+- [Enabling `zlibNX` hardware-accelerated data compression and decompression on AIX](#enabling-zlibnx-hardware-accelerated-data-compression-and-decompression-on-aix)
 
 
 ## Features and changes
@@ -47,9 +47,9 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 The following features are supported by OpenJ9:
 
 - [JEP 338](https://openjdk.java.net/jeps/338): Vector API (incubator)
-    - The OpenJ9 project is adding optimizations for this feature.
+    - OpenJ9 adds optimizations for this feature.
 - [JEP 390](https://openjdk.java.net/jeps/390): Warnings for value-based classes
-    - The OpenJ9 project is adding option `-XX:DiagnoseSyncOnValueBasedClasses=<number>`. See [`-XX:DiagnoseSyncOnValueBasedClasses=<number>`](xxdiagnosesynconvaluebasedclasses.md) for more details.
+    - OpenJ9 adds option [`-XX:DiagnoseSyncOnValueBasedClasses=<number>`](xxdiagnosesynconvaluebasedclasses.md) for compatibility with the reference implementation.
 - [JEP 395](https://openjdk.java.net/jeps/395): Records
 - [JEP 397](https://openjdk.java.net/jeps/397): Sealed Classes (second preview)
 
@@ -84,11 +84,11 @@ WARNING: All illegal access operations will be denied in a future release
 
 The `-verbose:module` option is now supported for Java 11 and later releases. This option writes information to `stderr` for each module that is loaded and unloaded.
 
-### Change the default `zlib` library on AIX&reg;
+### Enabling `zlibNX` hardware-accelerated data compression and decompression on AIX
 
-OpenJ9 for AIX&reg; uses the system `zlib` library by default instead of a bundled copy.
+By default, AIX&reg; uses the system `zlib` library for data compression and decompression.
 
-OpenJ9 on AIX&reg; systems uses the hardware-accelerated `zlibNX` if the Nest accelerators (NX) co-processor is enabled and the library is installed. To learn more about hardware acceleration and the `zlibNX` library see [Hardware acceleration](introduction.md#hardware-acceleration).
+On systems that contain the Nest accelerator (NX) co-processor, OpenJ9 now uses the `zlibNX` library instead, if it is installed. To learn more about hardware acceleration and the `zlibNX` library, see [Hardware acceleration](introduction.md#hardware-acceleration).
 
 ## Full release information
 

--- a/docs/xxdiagnosesynconvaluebasedclasses.md
+++ b/docs/xxdiagnosesynconvaluebasedclasses.md
@@ -24,16 +24,19 @@
 
 # -XX:DiagnoseSyncOnValueBasedClasses
 
-![Start of content that applies only to Java 16 and later](cr/java16plus.png) This option provides warnings about improper attempts to synchronize on instances of a value-based class. ![End of content that applies only to Java 16 or later](cr/java_close.png)
+![Start of content that applies only to Java 16 and later](cr/java16plus.png) This HotSpot option provides warnings about improper attempts to synchronize on instances of a value-based class. The option is recognized by OpenJ9 for compatibility.
 
 
 ## Syntax
 
         -XX:DiagnoseSyncOnValueBasedClasses=<number>
 
-Where <number> is one of the following values:
 
-   - 1: OpenJ9 throws a VirtualMachineError on improper attempts to synchronize on instances of value-based classes.
-   - 2: OpenJ9 prints a warning message on improper attempts to synchronize on instances of value-based classes.
+| `<number>` value  | Effect                                       |
+|-------------------|----------------------------------------------|
+| 1                 | Generate `VirtualMachineError` error         |
+| 2                 | Print a warning message                      |
+
+
 
 <!-- ==== END OF TOPIC ==== xxdiagnosesynconvaluebasedclasses.md ==== -->


### PR DESCRIPTION
- JEP 390: Add -XX option to migration topic. Fix missing `<number>` and add table for options. Minor updates to release topic.
- Style changes for zlibNX updates.

Signed-off-by: SueChaplain <sue_chaplain@uk.ibm.com>