### PR TITLE
Add scan ordering options and new default for balanced

### DIFF
--- a/docs/gc_overview.md
+++ b/docs/gc_overview.md
@@ -130,7 +130,7 @@ A GC *scavenge* operation is triggered by an allocation failure in the *nursery*
 
 2. Main
 
-    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap. If new objects are found, they are added to the work stack. If an object is reachable, it is copied from the *allocate* space to the *survivor* space in the nursery area or to the *tenure* area if the object has reached a particular age.
+    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap by using the *hierarchical scan ordering* mode ([`-Xgc:hierarchicalScanOrdering`](xgc.md#hierarchicalscanordering)). If new objects are found, they are added to the work stack. If an object is reachable, it is copied from the *allocate* space to the *survivor* space in the nursery area or to the *tenure* area if the object has reached a particular age.
 
 3. Final
 
@@ -150,7 +150,7 @@ A GC *copy forward* operation is similar to a scavenge operation but is triggere
 
 2. Main
 
-    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap. If new objects are found, they are added to the work stack. If an object is reachable, it is moved to another region of the same age or to an empty region of the same age in the heap. The age of all regions in the heap is then incremented by 1, except for the oldest region (age 24).
+    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap by using *dynamic breadth first scan ordering* mode ([`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering)). If new objects are found, they are added to the work stack. If an object is reachable, it is moved to another region of the same age or to an empty region of the same age in the heap. The age of all regions in the heap is then incremented by 1, except for the oldest region (age 24).
 
 3. Final
 

--- a/docs/version0.26.md
+++ b/docs/version0.26.md
@@ -1,0 +1,54 @@
+<!--
+* Copyright (c) 2017, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# What's new in version 0.26.0
+
+The following new features and notable changes since v 0.25.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Change in default behavior for the `balanced` garbage collection policy](#change-in-default-behavior-for-the-balanced-garbage-collection-gc-policy)
+
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.26.0 supports OpenJDK 8, 11, and 16.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Change in default behavior for the `balanced` garbage collection (GC) policy
+
+In this release, a new scan mode, [`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering), is used during `balanced` GC copy forward operations that is expected to improve performance.
+
+For more information about this type of operation, see [GC copy forward operation](gc_overview.md#gc-copy-forward-operation).
+
+You can revert to the behavior in earlier releases by setting [`-Xgc:breadthFirstScanOrdering`](xgc.md#breadthfirstscanordering) when you start your application.
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 v0.25.0 and v0.26.0 releases, see the [Release notes](https://github.com/eclipse/openj9/blob/master/doc/release-notes/0.26/0.26.md).
+
+
+<!-- ==== END OF TOPIC ==== version0.26.md ==== -->

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -34,14 +34,17 @@ Options that change the behavior of the Garbage Collector (GC).
 
 | Parameter                                                                 | Effect                                                                                                    |
 |---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| [`breadthFirstScanOrdering`         ](#breadthfirstscanordering         ) | Sets the scan mode to breadth first.                                             |
 | [`concurrentScavenge`               ](#concurrentscavenge               ) | Enables a garbage collection (GC) mode with less pause times.                                             |
 | [`dnssExpectedTimeRatioMaximum`     ](#dnssexpectedtimeratiomaximum     ) | Sets the maximum time to spend on GC of the nursery area.                                                 |
 | [`dnssExpectedTimeRatioMinimum`     ](#dnssexpectedtimeratiominimum     ) | Sets the minimum time to spend on GC of the nursery area.                                                 |
+| [`dynamicBreadthFirstScanOrdering`  ](#dynamicbreadthfirstscanordering  ) | Sets scan mode to dynamic breadth first.                                             |
 | [`excessiveGCratio`                 ](#excessivegcratio                 ) | Sets a boundary value beyond which GC is deemed to be excessive.                                          |
+| [`hierarchicalScanOrdering`         ](#hierarchicalscanordering         ) | Sets scan mode to hierarchical.                                             |
 | [`minContractPercent`               ](#mincontractpercent               ) | Sets the minimum percentage of the heap that can be contracted at any given time.                         |
 | [`maxContractPercent`               ](#maxcontractpercent               ) | Sets the maximum percentage of the heap that can be contracted at any given time.                         |
-| [`overrideHiresTimerCheck`          ](#overridehirestimercheck          ) | Overrides GC operating system checks for timer resolution.                                                |
 | [`noConcurrentScavenge`             ](#noconcurrentscavenge             ) | Disables concurrent scavenge.                                                                             |
+| [`overrideHiresTimerCheck`          ](#overridehirestimercheck          ) | Overrides GC operating system checks for timer resolution.                                                |
 | [`preferredHeapBase`                ](#preferredheapbase                ) | Sets a memory range for the Java&trade; heap. (AIX&reg;, Linux&reg;, macOS&reg;, and Windows&trade; only) |
 | [`scvNoAdaptiveTenure`              ](#scvnoadaptivetenure              ) | Turns off the adaptive tenure age in the generational concurrent GC policy.                               |
 | [`scvTenureAge`                     ](#scvtenureage                     ) | Sets the initial scavenger tenure age in the generational concurrent GC policy.                           |
@@ -50,6 +53,12 @@ Options that change the behavior of the Garbage Collector (GC).
 | [`tlhInitialSize`                   ](#tlhinitialsize                   ) | Sets the initial size of the thread local heap.                                                           |
 | [`tlhMaximumSize`                   ](#tlhmaximumsize                   ) | Sets the maximum size of the thread local heap.                                                           |
 | [`verboseFormat`                    ](#verboseformat                    ) | Sets the verbose GC format.                                                                               |
+
+### `breadthFirstScanOrdering`
+
+         -Xgc:breadthFirstScanOrdering
+
+: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to breadth first mode. The scan mode reflects the method for traversing the object graph and is also known as *Cheney's algorithm*.
 
 ### `concurrentScavenge`
 
@@ -104,6 +113,12 @@ Options that change the behavior of the Garbage Collector (GC).
 
 : The minimum amount of time spent on garbage collection of the nursery area, expressed as a percentage of the overall time for the last three GC intervals.
 
+### `dynamicBreadthFirstScanOrdering`
+
+         -Xgc:dynamicBreadthFirstScanOrdering
+
+: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to dynamic breadth first mode. This scan mode reflects the method for traversing the object graph and is a variant that adds *partial depth first traversal* on top of the breadth first scan mode. The aim of dynamic breadth first mode is driven by object field hotness. This mode is the default for the `balanced` GC policy.
+
 ### `excessiveGCratio`
 
         -Xgc:excessiveGCratio=<value>
@@ -115,6 +130,12 @@ Options that change the behavior of the Garbage Collector (GC).
 : where `<value>` is a percentage of total application run time that is not spent in GC.
 
     The default value is 95, which means that anything over 5% of total application run time spent on GC is deemed excessive. This option can be used only when [`-Xenableexcessivegc`](xenableexcessivegc.md) is set (enabled by default).
+
+### `HierarchicalScanOrdering`
+
+        -Xgc:hierarchicalScanOrdering
+
+: This option sets the scan mode for the scavenge operation (`gencon` GC policy) to hierarchical mode. This mode reflects the method for traversing the object graph and adds partial depth first traversal on top of breadth first scan mode. The aim of hierarchical mode is to minimize object distances. This option is the default for the `gencon` GC policy.
 
 ### `minContractPercent`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,11 +105,12 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.26.0"                                                       : version0.26.md
         - "Version 0.25.0"                                                       : version0.25.md
         - "Version 0.24.0"                                                       : version0.24.md
         - "Version 0.23.0"                                                       : version0.23.md
-        - "Version 0.22.0"                                                       : version0.22.md
         - "Earlier releases" :
+            - "Version 0.22.0"                                                   : version0.22.md
             - "Version 0.21.0"                                                   : version0.21.md
             - "Version 0.20.0"                                                   : version0.20.md
             - "Version 0.19.0"                                                   : version0.19.md


### PR DESCRIPTION
Add the 3 `-Xgc` suboptions that control scan ordering for GC operations
that evacuate objects in the heap.

Add the change in behavior for `balanced` to use dynamic breadth first scan mode.

Closes: #703

Signed-off-by: Sue-Chaplain <sue_chaplain@uk.ibm.com>