### PR TITLE
Update DockerHub namespace to eclipseopenj9

### DIFF
--- a/JenkinsFile_build_container.groovy
+++ b/JenkinsFile_build_container.groovy
@@ -21,7 +21,7 @@
  * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-NAMESPACE = 'eclipse'
+NAMESPACE = 'eclipseopenj9'
 CONTAINER_NAME = 'openj9-docs'
 
 timeout(time: 6, unit: 'HOURS') {

--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -21,7 +21,7 @@
  * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-NAMESPACE = 'eclipse'
+NAMESPACE = 'eclipseopenj9'
 CONTAINER_NAME = 'openj9-docs'
 ARCHIVE = 'doc.tar.gz'
 HTTP = 'https://'


### PR DESCRIPTION
See [Eclipse Bugzilla 572408](https://bugs.eclipse.org/bugs/show_bug.cgi?id=572408)

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

cc @mbarbero