### PR TITLE
Add missing class unloading options

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -100,11 +100,13 @@ More information about Concurrent Scavenge mode can be found in the blog post [C
 
 ## `balanced` policy
 
+**(64-bit only)**
+
 The Balanced GC policy ([`-Xgcpolicy:balanced`](xgcpolicy.md#balanced)) evens out pause times and reduces the overhead of some of the costlier operations that are typically associated with garbage collection, such as compaction and class unloading. The Java heap is divided into a large number of regions (1,000 - 2,000), which are managed individually by an incremental generational collector to reduce the maximum pause time on large heaps and increase the efficiency of garbage collection. The aim of the policy is to avoid global garbage collections by matching object allocation and survival rates.
 
 ###  When to use
 
-The Balanced policy suits applications that require large heaps (>64 Mb) on 64-bit platforms. This policy might be a good alternative for applications that experience unacceptable pause times with `gencon`.
+The Balanced policy suits applications that require large heaps (>64 MB) on 64-bit platforms. This policy might be a good alternative for applications that experience unacceptable pause times with `gencon`.
 
 
 - If you have problems with application pause times that are caused by global garbage collections, particularly compactions, this policy might improve application performance.

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -24,7 +24,7 @@
 
 # -Xgc
 
-Options that change the behavior of the Garbage Collector (GC).
+Options that change the behavior of the garbage collector.
 
 ## Syntax
 
@@ -35,7 +35,9 @@ Options that change the behavior of the Garbage Collector (GC).
 | Parameter                                                                 | Effect                                                                                                    |
 |---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | [`breadthFirstScanOrdering`         ](#breadthfirstscanordering         ) | Sets the scan mode to breadth first.                                             |
-| [`concurrentScavenge`               ](#concurrentscavenge               ) | Enables a garbage collection (GC) mode with less pause times.                                             |
+| [`classUnloadingKickoffThreshold`   ](#classunloadingkickoffthreshold   ) | Sets a threshold to start an early concurrent global garbage collection (GC) cycle due to recent, heavy class loading activity  |
+| [`classUnloadingThreshold`          ](#classunloadingthreshold          ) | Sets a threshold to trigger a class unloading operation in a global GC cycle                                     |
+| [`concurrentScavenge`               ](#concurrentscavenge               ) | Enables a GC mode with less pause times.                                             |
 | [`dnssExpectedTimeRatioMaximum`     ](#dnssexpectedtimeratiomaximum     ) | Sets the maximum time to spend on GC of the nursery area.                                                 |
 | [`dnssExpectedTimeRatioMinimum`     ](#dnssexpectedtimeratiominimum     ) | Sets the minimum time to spend on GC of the nursery area.                                                 |
 | [`dynamicBreadthFirstScanOrdering`  ](#dynamicbreadthfirstscanordering  ) | Sets scan mode to dynamic breadth first.                                             |
@@ -59,6 +61,26 @@ Options that change the behavior of the Garbage Collector (GC).
          -Xgc:breadthFirstScanOrdering
 
 : This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to breadth first mode. The scan mode reflects the method for traversing the object graph and is also known as *Cheney's algorithm*.
+
+### `classUnloadingKickoffThreshold`
+
+         -Xgc:classUnloadingKickoffThreshold=<value>
+
+: Where `<value>` is equal to the number of class loaders plus the number of anonymous classes that are loaded since the previous class unloading operation.
+
+: This option sets a threshold that is used to start an early concurrent global GC cycle due to recent class loading activity. The default value is 80000.
+
+: This option  is applicable to the following GC policies: `gencon` and `optavgpause`.
+
+### `classUnloadingThreshold`
+
+         -Xgc:classUnloadingThreshold=<value>
+
+: Where `<value>` is equal to the number of class loaders plus the number of anonymous classes that are loaded since the previous class unloading operation.
+
+: This option sets a threshold that is used to trigger an optional GC class unloading operation in a global GC cycle, irrespective of how the global GC cycle is triggered. The default value is 6.
+
+: This option  is applicable to the following GC policies: `gencon`, `optavgpause`, and `optthruput`.
 
 ### `concurrentScavenge`
 

--- a/docs/xgcpolicy.md
+++ b/docs/xgcpolicy.md
@@ -36,7 +36,7 @@ Controls which Garbage Collection (GC) policy is used for your Java&trade; appli
 | Parameter                                                                    | Default |
 |------------------------------------------------------------------------------|---------|
 | [`gencon`](#gencon)                                                          | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| [`balanced`](#balanced)                                                      |         |
+| [`balanced`](#balanced-64-bit-only) (64-bit only)                            |         |
 | [`metronome`](#metronome-aix-linux-x86-only) (AIX&reg;, Linux&reg; x86 only) |         |
 | [`optavgpause`](#optavgpause)                                                |         |
 | [`optthruput`](#optthruput)                                                  |         |
@@ -53,7 +53,7 @@ For a detailed description of the policies, when to use them, and how they work,
 : To learn more about this policy, when to use it, and how it works, see [Garbage collection: `gencon` policy](gc.md#gencon-policy-default).
 
 
-### `balanced`
+### `balanced` (64-bit only)
 
         -Xgcpolicy:balanced
 


### PR DESCRIPTION
- adds two -Xgc suboptions that trigger GCs related to class unloading activity.

Closes: #756

Signed-off-by: SueChaplain <sue_chaplain@uk.ibm.com>