### PR TITLE
Adaptive GC Threading Documentation

### DIFF
--- a/docs/version0.27.md
+++ b/docs/version0.27.md
@@ -26,6 +26,16 @@
 
 The following new features and notable changes since v 0.26.0 are included in this release:
 
-- [New `-XX:[+|-]AdaptiveGCThreading` option added](xxadaptivegcthreading.md)
+- [New `-XX:[+|-]AdaptiveGCThreading` option added](#new-xx-adaptivegcthreading-option-added)
+
+## Features and changes
+
+### Performance improvements
+
+### New `-XX:[+|-]AdaptiveGCThreading` option added
+
+To optimize performance, you can now enable adaptive threading to automatically tune the number of active parallel garbage collection (GC) threads. When enabled, the GC thread count is dynamically adjusted from collection cycle to cycle to account for changes in the workload and consider the available resources. When parallel workloads decrease, less threads can be used, reducing the overhead and freeing up resources for other processing activities.
+
+Use the [`-xgcmaxthreads`](xgcmaxthreads.md) option with the [`-XX:+AdaptiveGCThreading`](xxadaptivegcthreading.md) option to specify a thread count limit.
 
 <!-- ==== END OF TOPIC ==== version0.27.md ==== -->

--- a/docs/version0.27.md
+++ b/docs/version0.27.md
@@ -22,16 +22,10 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -XX:ParallelGCMaxThreads
+# What's new in version 0.27.0
 
-This option specifies the maximum number of threads that can be used during parallel operations of the garbage collector. Unlike [`-XX:ParallelGCThreads`](xxparallelgcthreads.md), this option does not enforce a thread count, but can be used to allow the garbage collector to adjust the number of parallel GC threads, if used with the [Adaptive GC Threading](xxadaptivegcthreading.md) option.
+The following new features and notable changes since v 0.26.0 are included in this release:
 
-## Syntax
+- [New `-XX:[+|-]AdaptiveGCThreading` option added](xxadaptivegcthreading.md)
 
-        -XX:ParallelGCMaxThreads=<number>
-
-Where `<number>` is the maximum number of threads that can be used for parallel operations. 
-
-This option is directly mapped to [`-Xgcmaxthreads`](xgcmaxthreads.md).
-
-<!-- ==== END OF TOPIC ==== xxparallelgcmaxthreads.md ==== -->
+<!-- ==== END OF TOPIC ==== version0.27.md ==== -->

--- a/docs/xgcmaxthreads.md
+++ b/docs/xgcmaxthreads.md
@@ -24,8 +24,7 @@
 
 # -Xgcmaxthreads
 
-
-Specifies the maximum number of threads that the Garbage Collector can use for parallel operations. This option behaves like [`-Xgcthreads`](xgcthreads.md) except it doesn't force the thread count. This allows for collector adjustments (allows the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization) with a thread count limit.
+Specifies the maximum number of threads that the garbage collector can use for parallel operations. This option behaves in the same way as [`-Xgcthreads`](xgcthreads.md) but does not enforce a fixed thread count, which allows the garbage collector to adjust the thread count when used with the [`-XX:+AdaptiveGCThreading`](xxadaptivegcthreading.md) option.
 
 ## Syntax
 

--- a/docs/xgcmaxthreads.md
+++ b/docs/xgcmaxthreads.md
@@ -22,21 +22,15 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -XX:ParallelGCThread
+# -Xgcmaxthreads
 
-This Oracle HotSpot option specifies the number of threads that are used during parallel operations of the default garbage collector. This option is recognized by OpenJ9 and provided for compatibility.
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
-
-- This option forces the thread count and prevents the collector from adjusting the thread count (disables the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization).
-- To allow for collector adjustments, [`-XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md) can be used instead. Rather than forcing the thread count `-XX:ParallelGCMaxThreads` sets a limit on the thread count.
+Specifies the maximum number of threads that the Garbage Collector can use for parallel operations. This option behaves like [`-Xgcthreads`](xgcthreads.md) except it doesn't force the thread count. This allows for collector adjustments (allows the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization) with a thread count limit.
 
 ## Syntax
 
-        -XX:ParallelGCThreads=<number>
+        -Xgcmaxthreads<number>
 
-Where `<number>` is the number of threads that are used for parallel operations. 
+Where `<number>` is the maximum number of threads that can be used for parallel operations.
 
-Within OpenJ9 this option is directly mapped to [`-Xgcthreads`](xgcthreads.md).
-
-<!-- ==== END OF TOPIC ==== xxparallelgcthreads.md ==== -->
+<!-- ==== END OF TOPIC ==== xgcmaxthreads.md ==== -->

--- a/docs/xgcthreads.md
+++ b/docs/xgcthreads.md
@@ -25,7 +25,12 @@
 # -Xgcthreads
 
 
-Sets the number of threads that the Garbage Collector uses for parallel operations.
+Sets the number of threads that the Garbage Collector uses for parallel operations. 
+
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
+
+- This option forces the thread count and prevents the collector from adjusting the thread count (disables the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization).
+- To allow for collector adjustments, [`-xgcmaxthreads`](xgcmaxthreads.md) can be used instead. Rather than forcing the thread count `-Xgcmaxthreads` sets a limit on the thread count.
 
 ## Syntax
 
@@ -36,7 +41,6 @@ Sets the number of threads that the Garbage Collector uses for parallel operatio
 The total number of GC threads is composed of one application thread with the remainder being dedicated GC threads. By default, the number is set to `n-1`, where `n` is the number of reported CPUs, up to a maximum of 64. Where SMT or hyperthreading is in place, the number of reported CPUs is larger than the number of physical CPUs. Likewise, where virtualization is in place, the number of reported CPUs is the number of virtual CPUs assigned to the operating system. To set it to a different number, for example 4, use `-Xgcthreads4`. The minimum valid value is 1, which disables parallel operations, at the cost of performance. No advantage is gained if you increase the number of threads to more than the default setting.
 
 On systems running multiple VMs or in LPAR environments where multiple VMs can share the same physical CPUs, you might want to restrict the number of GC threads used by each VM. The restriction helps prevent the total number of parallel operation GC threads for all VMs exceeding the number of physical CPUs present, when multiple VMs perform garbage collection at the same time.
-
 
 
 <!-- ==== END OF TOPIC ==== xgcthreads.md ==== -->

--- a/docs/xgcthreads.md
+++ b/docs/xgcthreads.md
@@ -25,12 +25,11 @@
 # -Xgcthreads
 
 
-Sets the number of threads that the Garbage Collector uses for parallel operations. 
+Sets the number of threads that the garbage collector uses for parallel operations. 
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
 
-- This option forces the thread count and prevents the collector from adjusting the thread count (disables the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization).
-- To allow for collector adjustments, [`-xgcmaxthreads`](xgcmaxthreads.md) can be used instead. Rather than forcing the thread count `-Xgcmaxthreads` sets a limit on the thread count.
+This option enforces a fixed thread count and cannot be used with the [`-XX:+AdaptiveGCThreading`](xxadaptivegcthreading.md) option, which enables the garbage collector to adjust the number of parallel threads based on heuristics. If you want to use [`-XX:+AdaptiveGCThreading`](xxadaptivegcthreading.md), use [`-Xgcmaxthreads`](xgcmaxthreads.md) instead of `-Xgcthreads`.
 
 ## Syntax
 

--- a/docs/xxadaptivegcthreading.md
+++ b/docs/xxadaptivegcthreading.md
@@ -1,0 +1,60 @@
+<!--
+* Copyright (c) 2017, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:\[+|-\]AdaptiveGCThreading
+
+When this option is enabled, the active GC thread count is adjusted for each collection cycle based on heuristics. That is, once a collection cycle successfully completes, the collector evaluates parallelism using aggregated thread busy/stall statistics gathered during the completed cycle and projects a new thread count for the next cycle. For example, the thread count may be reduced if it is determined that unnecessary overhead was incurred as a result of synchronization, lack of work sharing or CPU availability. Similarly, the thread count may be increased if there's an opportunity to gain benefits from increased parallelism. 
+
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
+
+- This option is ignored when the GC thread count is forced, for example when using the [`-xgcthreads`](xgcthreads.md) or [`-XX:ParallelGCThreads`](xxparallelgcthreads.md) options.
+- The [`default GC thread count`](xgcthreads.md#explanation) is used as max thread count for adaptive threading. However, an upper bound can be specified using [`-xgcmaxthreads`](xgcmaxthreads.md) or [`-XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md) 
+
+:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** This feature is currently only available with the `Gencon` GC policy.
+
+## Syntax
+
+        -XX:[+|-]AdaptiveGCThreading
+
+| Setting                            | Effect  | Default                                                                            |
+|------------------------------------|---------|:----------------------------------------------------------------------------------:|
+| `-XX:+AdaptiveGCThreading` | Enable  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+| `-XX:-AdaptiveGCThreading` | Disable |               |
+
+This optimization aims to automatically tune the GC thread count. Manually tuning and forcing the thread count may be sub-optimal as the ability to parallelize a workload changes over the lifetime of an application.
+
+You can check the active thread count value used by the garbage collector to complete the cycle by inspecting verbose GC output. The following example shows active thread count being reduced from 8 to 3:
+
+```
+<gc-end id="8" type="scavenge" contextid="4" durationms="2.248" usertimems="3.694" systemtimems="1.345" stalltimems="11.003" timestamp="2021-03-12T01:35:10.768" activeThreads="8">
+<gc-end id="20" type="scavenge" contextid="16" durationms="7.045" usertimems="6.360" systemtimems="0.955" stalltimems="31.964" timestamp="2021-03-12T01:35:10.777" activeThreads="6">
+<gc-end id="32" type="scavenge" contextid="28" durationms="1.943" usertimems="7.112" systemtimems="0.454" stalltimems="6.076" timestamp="2021-03-12T01:35:10.781" activeThreads="5">
+<gc-end id="44" type="scavenge" contextid="40" durationms="1.253" usertimems="2.910" systemtimems="0.297" stalltimems="2.416" timestamp="2021-03-12T01:35:10.788" activeThreads="4">
+<gc-end id="56" type="scavenge" contextid="52" durationms="1.487" usertimems="3.991" systemtimems="0.447" stalltimems="2.918" timestamp="2021-03-12T01:35:10.790" activeThreads="4">
+<gc-end id="68" type="scavenge" contextid="64" durationms="0.400" usertimems="1.002" systemtimems="0.178" stalltimems="0.658" timestamp="2021-03-12T01:35:10.791" activeThreads="4">
+<gc-end id="80" type="scavenge" contextid="76" durationms="0.187" usertimems="1.099" systemtimems="0.127" stalltimems="0.112" timestamp="2021-03-12T01:35:10.792" activeThreads="3">
+<gc-end id="92" type="scavenge" contextid="88" durationms="0.195" usertimems="0.940" systemtimems="0.114" stalltimems="0.067" timestamp="2021-03-12T01:35:10.796" activeThreads="3">
+<gc-end id="104" type="scavenge" contextid="100" durationms="0.277" usertimems="0.899" systemtimems="0.118" stalltimems="0.139" timestamp="2021-03-12T01:35:10.797" activeThreads="3">
+```
+<!-- ==== END OF TOPIC ==== xxadaptivegcthreading.md ==== -->

--- a/docs/xxadaptivegcthreading.md
+++ b/docs/xxadaptivegcthreading.md
@@ -24,14 +24,14 @@
 
 # -XX:\[+|-\]AdaptiveGCThreading
 
-When this option is enabled, the active GC thread count is adjusted for each collection cycle based on heuristics. That is, once a collection cycle successfully completes, the collector evaluates parallelism using aggregated thread busy/stall statistics gathered during the completed cycle and projects a new thread count for the next cycle. For example, the thread count may be reduced if it is determined that unnecessary overhead was incurred as a result of synchronization, lack of work sharing or CPU availability. Similarly, the thread count may be increased if there's an opportunity to gain benefits from increased parallelism. 
+:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** Currently, this feature is available only with the `gencon` GC policy.
+
+When this option is enabled, the active GC thread count is adjusted for each garbage collection (GC) cycle based on heuristics. That is, when a GC cycle successfully completes, the collector evaluates parallelism using aggregated thread statistics gathered during the completed cycle and projects a new thread count for the next cycle. For example, the thread count might be reduced if it is determined that an unnecessary overhead was incurred as a result of synchronization, lack of work sharing, or CPU availability. Similarly, the thread count may be increased if there's an opportunity to gain benefits from increased parallelism. 
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
 
-- This option is ignored when the GC thread count is forced, for example when using the [`-xgcthreads`](xgcthreads.md) or [`-XX:ParallelGCThreads`](xxparallelgcthreads.md) options.
-- The [`default GC thread count`](xgcthreads.md#explanation) is used as max thread count for adaptive threading. However, an upper bound can be specified using [`-xgcmaxthreads`](xgcmaxthreads.md) or [`-XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md) 
-
-:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** This feature is currently only available with the `Gencon` GC policy.
+- This option is ignored when the GC thread count is enforced, for example when using the [`-xgcthreads`](xgcthreads.md) or [`-XX:ParallelGCThreads`](xxparallelgcthreads.md) options.
+- By default, the number of GC threads is based on the number of CPUs reported by the operating system. This value is used as the maximum thread count. However, an upper bound can be specified by using [`-xgcmaxthreads`](xgcmaxthreads.md) or [` XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md).
 
 ## Syntax
 
@@ -42,9 +42,9 @@ When this option is enabled, the active GC thread count is adjusted for each col
 | `-XX:+AdaptiveGCThreading` | Enable  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | `-XX:-AdaptiveGCThreading` | Disable |               |
 
-This optimization aims to automatically tune the GC thread count. Manually tuning and forcing the thread count may be sub-optimal as the ability to parallelize a workload changes over the lifetime of an application.
+This optimization aims to automatically tune the GC thread count. Manually tuning and setting a thread count can be suboptimal because workloads typically change over the lifetime of an application.
 
-You can check the active thread count value used by the garbage collector to complete the cycle by inspecting verbose GC output. The following example shows active thread count being reduced from 8 to 3:
+You can check the active thread count value that is used by the garbage collector to complete the cycle by inspecting verbose GC output. The following example shows active thread count being reduced from 8 to 3:
 
 ```
 <gc-end id="8" type="scavenge" contextid="4" durationms="2.248" usertimems="3.694" systemtimems="1.345" stalltimems="11.003" timestamp="2021-03-12T01:35:10.768" activeThreads="8">

--- a/docs/xxparallelgcmaxthreads.md
+++ b/docs/xxparallelgcmaxthreads.md
@@ -22,21 +22,16 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -XX:ParallelGCThread
+# -XX:ParallelGCMaxThreads
 
-This Oracle HotSpot option specifies the number of threads that are used during parallel operations of the default garbage collector. This option is recognized by OpenJ9 and provided for compatibility.
-
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
-
-- This option forces the thread count and prevents the collector from adjusting the thread count (disables the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization).
-- To allow for collector adjustments, [`-XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md) can be used instead. Rather than forcing the thread count `-XX:ParallelGCMaxThreads` sets a limit on the thread count.
+This option specifies the maximum number of threads that can be used during parallel operations of the garbage collector. Unlike [`-XX:ParallelGCThreads`](xxparallelgcthreads.md), this option doesn't force the thread count and allows for collector adjustments (allows for the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization).
 
 ## Syntax
 
-        -XX:ParallelGCThreads=<number>
+        -XX:ParallelGCMaxThreads=<number>
 
-Where `<number>` is the number of threads that are used for parallel operations. 
+Where `<number>` is the maximum number of threads that can be used for parallel operations. 
 
-Within OpenJ9 this option is directly mapped to [`-Xgcthreads`](xgcthreads.md).
+This option is directly mapped to [`-Xgcmaxthreads`](xgcmaxthreads.md).
 
-<!-- ==== END OF TOPIC ==== xxparallelgcthreads.md ==== -->
+<!-- ==== END OF TOPIC ==== xxparallelgcmaxthreads.md ==== -->

--- a/docs/xxparallelgcthreads.md
+++ b/docs/xxparallelgcthreads.md
@@ -28,8 +28,7 @@ This Oracle HotSpot option specifies the number of threads that are used during 
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
 
-- This option forces the thread count and prevents the collector from adjusting the thread count (disables the [Adaptive GC Threading](xxadaptivegcthreading.md) optimization).
-- To allow for collector adjustments, [`-XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md) can be used instead. Rather than forcing the thread count `-XX:ParallelGCMaxThreads` sets a limit on the thread count.
+This option enforces the thread count and cannot be used with the [`-XX:+AdaptiveGCThreading`](xxadaptivegcthreading.md) option, which enables the garbage collector to adjust the number of parallel threads based on heuristics. If you want to use [`-XX:+AdaptiveGCThreading`](xxadaptivegcthreading.md), use [`-XX:ParallelGCMaxThreads`](xxparallelgcmaxthreads.md) instead of `-XX:ParallelGCThreads`.
 
 ## Syntax
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,6 +251,7 @@ nav:
             - "-Xgc:splitheap"                                                   : xgcsplitheap.md
             - "-Xgcpolicy"                                                       : xgcpolicy.md
             - "-Xgcthreads"                                                      : xgcthreads.md
+            - "-Xgcmaxthreads"                                                   : xgcmaxthreads.md
             - "-Xgcworkpackets"                                                  : xgcworkpackets.md
             - "-Xint"                                                            : xint.md
             - "-Xiss"                                                            : xss.md                             # redirect
@@ -330,6 +331,7 @@ nav:
         - "JVM -XX options" :
             - "Using -XX options"                                                : xx_jvm_commands.md
             - "-XXActiveProcessorCount"                                          : xxactiveprocessorcount.md
+            - "-XX:[+|-]AdaptiveGCThreading"                                     : xxadaptivegcthreading.md
             - "-XXallowvmshutdown"                                               : xxallowvmshutdown.md
             - "-XX:[+|-]AlwaysPreTouch"                                          : xxalwayspretouch.md
             - "-XX:[+|-]ClassRelationshipVerifier"                               : xxclassrelationshipverifier.md
@@ -368,6 +370,7 @@ nav:
             - "-XX:[+|-]PageAlignDirectMemory"                                   : xxpagealigndirectmemory.md
             - "-XX:ParallelCMSThreads"                                           : xxparallelcmsthreads.md
             - "-XX:ParallelGCThreads"                                            : xxparallelgcthreads.md
+            - "-XX:ParallelGCMaxThreads"                                            : xxparallelgcmaxthreads.md
             - "-XX:[+|-]PortableSharedCache"                                     : xxportablesharedcache.md
             - "-XX:[+|-]PositiveIdentityHash"                                    : xxpositiveidentityhash.md
             - "-XX:[+|-]PrintCodeCache"                                          : xxprintcodecache.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.27.0"                                                       : version0.27.md
         - "Version 0.26.0"                                                       : version0.26.md
         - "Version 0.25.0"                                                       : version0.25.md
         - "Version 0.24.0"                                                       : version0.24.md
@@ -249,9 +250,9 @@ nav:
             - "-Xfuture"                                                         : xfuture.md
             - "-Xgc"                                                             : xgc.md
             - "-Xgc:splitheap"                                                   : xgcsplitheap.md
+            - "-Xgcmaxthreads"                                                   : xgcmaxthreads.md            
             - "-Xgcpolicy"                                                       : xgcpolicy.md
             - "-Xgcthreads"                                                      : xgcthreads.md
-            - "-Xgcmaxthreads"                                                   : xgcmaxthreads.md
             - "-Xgcworkpackets"                                                  : xgcworkpackets.md
             - "-Xint"                                                            : xint.md
             - "-Xiss"                                                            : xss.md                             # redirect
@@ -369,8 +370,8 @@ nav:
             - "-XXnosuballoc32bitmem"                                            : xxnosuballoc32bitmem.md
             - "-XX:[+|-]PageAlignDirectMemory"                                   : xxpagealigndirectmemory.md
             - "-XX:ParallelCMSThreads"                                           : xxparallelcmsthreads.md
+            - "-XX:ParallelGCMaxThreads"                                         : xxparallelgcmaxthreads.md
             - "-XX:ParallelGCThreads"                                            : xxparallelgcthreads.md
-            - "-XX:ParallelGCMaxThreads"                                            : xxparallelgcmaxthreads.md
             - "-XX:[+|-]PortableSharedCache"                                     : xxportablesharedcache.md
             - "-XX:[+|-]PositiveIdentityHash"                                    : xxpositiveidentityhash.md
             - "-XX:[+|-]PrintCodeCache"                                          : xxprintcodecache.md


### PR DESCRIPTION
With the introduction of Adaptive GC Threading optimization  (https://github.com/eclipse/openj9/pull/11999 & 
 https://github.com/eclipse/omr/pull/5830), new options need to  documented and some of the existing options need to be updated for  clarification.

Discussion on the behaviour, naming and interaction with existing  options can be found at https://github.com/eclipse/openj9/issues/12119.

New options:
**XX:**
`-XX:[+-]AdaptiveGCThreading` to enable/disable the GC adaptive threading  optimization.
`-XX:ParallelGCMaxThreads=` Mapped to Xgcmaxthreads (see below)

**Xgc:**
`-Xgcmaxthreads` The max number of threads available to Adaptive Threading  (Similar to Xgcthreads, except it doesn’t set forced thread count flag)

Existing `Xgcthreads` & `XX:ParallelGCThreads=` option pages updated  with notes to compare with new options.

Signed-off-by: Salman Rana <salman.rana@ibm.com>