### PR TITLE
Backout change for balanced GC policy

### DIFF
--- a/docs/gc_overview.md
+++ b/docs/gc_overview.md
@@ -150,7 +150,7 @@ A GC *copy forward* operation is similar to a scavenge operation but is triggere
 
 2. Main
 
-    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap by using *dynamic breadth first scan ordering* mode ([`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering)). If new objects are found, they are added to the work stack. If an object is reachable, it is moved to another region of the same age or to an empty region of the same age in the heap. The age of all regions in the heap is then incremented by 1, except for the oldest region (age 24).
+    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap<!-- by using *dynamic breadth first scan ordering* mode ([`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering))-->. If new objects are found, they are added to the work stack. If an object is reachable, it is moved to another region of the same age or to an empty region of the same age in the heap. The age of all regions in the heap is then incremented by 1, except for the oldest region (age 24).
 
 3. Final
 

--- a/docs/version0.26.md
+++ b/docs/version0.26.md
@@ -27,7 +27,6 @@
 The following new features and notable changes since v 0.25.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
-- [Change in default behavior for the `balanced` garbage collection policy](#change-in-default-behavior-for-the-balanced-garbage-collection-gc-policy)
 
 
 ## Features and changes
@@ -39,14 +38,6 @@ OpenJ9 release 0.26.0 supports OpenJDK 8, 11, and 16.
 For OpenJDK 8 and 11 builds that contain OpenJ9, see [Version 0.25.0](version0.25.md) for additional changes that have now been fully tested for these versions.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
-
-### Change in default behavior for the `balanced` garbage collection (GC) policy
-
-In this release, a new scan mode, [`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering), is used during `balanced` GC copy forward operations that is expected to improve performance.
-
-For more information about this type of operation, see [GC copy forward operation](gc_overview.md#gc-copy-forward-operation).
-
-You can revert to the behavior in earlier releases by setting [`-Xgc:breadthFirstScanOrdering`](xgc.md#breadthfirstscanordering) when you start your application.
 
 ## Full release information
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -40,7 +40,6 @@ Options that change the behavior of the garbage collector.
 | [`concurrentScavenge`               ](#concurrentscavenge               ) | Enables a GC mode with less pause times.                                             |
 | [`dnssExpectedTimeRatioMaximum`     ](#dnssexpectedtimeratiomaximum     ) | Sets the maximum time to spend on GC of the nursery area.                                                 |
 | [`dnssExpectedTimeRatioMinimum`     ](#dnssexpectedtimeratiominimum     ) | Sets the minimum time to spend on GC of the nursery area.                                                 |
-| [`dynamicBreadthFirstScanOrdering`  ](#dynamicbreadthfirstscanordering  ) | Sets scan mode to dynamic breadth first.                                             |
 | [`excessiveGCratio`                 ](#excessivegcratio                 ) | Sets a boundary value beyond which GC is deemed to be excessive.                                          |
 | [`hierarchicalScanOrdering`         ](#hierarchicalscanordering         ) | Sets scan mode to hierarchical.                                             |
 | [`minContractPercent`               ](#mincontractpercent               ) | Sets the minimum percentage of the heap that can be contracted at any given time.                         |
@@ -56,11 +55,12 @@ Options that change the behavior of the garbage collector.
 | [`tlhMaximumSize`                   ](#tlhmaximumsize                   ) | Sets the maximum size of the thread local heap.                                                           |
 | [`verboseFormat`                    ](#verboseformat                    ) | Sets the verbose GC format.                                                                               |
 
+
 ### `breadthFirstScanOrdering`
 
          -Xgc:breadthFirstScanOrdering
 
-: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to breadth first mode. The scan mode reflects the method for traversing the object graph and is also known as *Cheney's algorithm*.
+: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to breadth first mode. The scan mode reflects the method for traversing the object graph and is also known as *Cheney's algorithm*. This mode is the default for the `balanced` GC policy.
 
 ### `classUnloadingKickoffThreshold`
 
@@ -135,11 +135,11 @@ Options that change the behavior of the garbage collector.
 
 : The minimum amount of time spent on garbage collection of the nursery area, expressed as a percentage of the overall time for the last three GC intervals.
 
-### `dynamicBreadthFirstScanOrdering`
+<!--### `dynamicBreadthFirstScanOrdering`
 
          -Xgc:dynamicBreadthFirstScanOrdering
 
-: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to dynamic breadth first mode. This scan mode reflects the method for traversing the object graph and is a variant that adds *partial depth first traversal* on top of the breadth first scan mode. The aim of dynamic breadth first mode is driven by object field hotness. This mode is the default for the `balanced` GC policy.
+: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to dynamic breadth first mode. This scan mode reflects the method for traversing the object graph and is a variant that adds *partial depth first traversal* on top of the breadth first scan mode. The aim of dynamic breadth first mode is driven by object field hotness. This mode is the default for the `balanced` GC policy.-->
 
 ### `excessiveGCratio`
 
@@ -153,7 +153,7 @@ Options that change the behavior of the garbage collector.
 
     The default value is 95, which means that anything over 5% of total application run time spent on GC is deemed excessive. This option can be used only when [`-Xenableexcessivegc`](xenableexcessivegc.md) is set (enabled by default).
 
-### `HierarchicalScanOrdering`
+### `hierarchicalScanOrdering`
 
         -Xgc:hierarchicalScanOrdering
 


### PR DESCRIPTION
Scan ordering switched back to Breadth First due to underlying problems.

Closes: #768

Signed-off-by: SueChaplain <sue_chaplain@uk.ibm.com>