### PR TITLE
Deprecate jextract, replace with jpackcore

### DIFF
--- a/docs/diag_overview.md
+++ b/docs/diag_overview.md
@@ -63,7 +63,7 @@ A number of diagnostic tools are available with OpenJ9 to assist with the analys
 
 ### Dump extractor
 
-The dump extractor (`jextract`) supports a full analysis of core files on specific platforms by collecting key files from a system and packaging them into an archive along with a core dump. This archive file is extremely useful when reporting issues to the OpenJ9
+The dump extractor (`jpackcore`) supports a full analysis of core files on specific platforms by collecting key files from a system and packaging them into an archive along with a core dump. This archive file is extremely useful when reporting issues to the OpenJ9
 community, helping to ensure a faster analysis and turnaround. For more information, see
 [Dump extractor](tool_jextract.md).
 

--- a/docs/interface_dtfj.md
+++ b/docs/interface_dtfj.md
@@ -26,7 +26,7 @@
 
 The Diagnostic Tool Framework for Java&trade; (DTFJ) is a Java application programming interface (API) that is used to support the building of Java diagnostic tools. DTFJ works with data from a system dump or a Java dump.
 
-On Linux and AIX® operating systems, you can get more information from a system dump if you also have copies of executable files and libraries. You can run the `jextract` utility provided in the SDK to collect these files into a single archive for use in subsequent problem diagnosis. For more information, see [Dump extractor](tool_jextract.md).
+On Linux and AIX® operating systems, you can get more information from a system dump if you also have copies of executable files and libraries. You can run the `jpackcore` utility to collect these files into a single archive for use in subsequent problem diagnosis. For more information, see [Dump extractor](tool_jextract.md).
 
 The DTFJ API helps diagnostic tools access the following information:  
 

--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -42,19 +42,19 @@ The dump viewer is useful for diagnosing `OutOfMemoryError` exceptions in Java&t
 | Input option            | Explanation                                                                                            |
 |-------------------------|--------------------------------------------------------------------------------------------------------|
 | `-core <core file>`     | Specifies a dump file.                                                                                 |
-| `-zip <zip file>`       | Specifies a compressed file containing the core file (produced by the [dump extractor (`jextract`)](tool_jextract.md) tool on AIX&reg;, Linux&reg;, and macOS&reg; systems). |
+| `-zip <zip file>`       | Specifies a compressed file containing the core file (produced by the [dump extractor (`jpackcore`)](tool_jextract.md) tool on AIX&reg;, Linux&reg;, and macOS&reg; systems). |
 | `-notemp`               | By default, when you specify a file by using the `-zip` option, the contents are extracted to a temporary directory before processing. Use the `-notemp` option to prevent this extraction step, and run all subsequent commands in memory. |
 | `-J-Dcom.ibm.j9ddr.path.mapping=<mappings>` | The variable `<mappings>` is a list of native library mappings of the form `old-path=new-path`, using the usual path separator (a semi-colon (';') on Windows, and a colon (':') on other platforms). |
 | `-J-Dcom.ibm.j9ddr.library.path=<path>` | The variable `<path>` is a list of paths to search for native libraries, using the usual path separator (a semi-colon (';') on Windows, and a colon (':') on other platforms). |
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The `-core` option can be used with the `-zip` option to specify the core file in the compressed file. With these options, `jdmpview` shows multiple contexts, one for each source file that it identified in the compressed file.
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** On AIX and Linux, some `jdmpview` commands must locate the executable and the native libraries that are referenced by the core. For example, commands that relate to call-sites. 
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** On AIX and Linux, some `jdmpview` commands must locate the executable and the native libraries that are referenced by the core. For example, commands that relate to call-sites.
 A common scenario involves using `jdmpview` to examine core files that originate on different systems. However, if the executable and the libraries are in their original locations, `jdmpview` might not consider them. Therefore, first check the executable and the list of native libraries by running `jdmpview` on a core with the `info mod` command.
 
 - One way to assist `jdmpview` to locate those files is by specifying on the command line one or both of the path mapping option (`-J-Dcom.ibm.j9ddr.path.mapping=<mappings>`) and the library path option (`-J-Dcom.ibm.j9ddr.library.path=<path>`).
 
-- Alternatively, on the system where the core file was produced, you can use `jextract` to collect all the relevant files into a single zip archive. That archive can be unpacked, possibly on another system, into a new, empty directory. Running `jdmpview` in that new directory (where the core file will be located) should enable it to find all the data it needs, including information that might not be included in the core file itself, such as symbols or sections. When you use an archive produced by `jextract`, setting the path or library mapping system properties should not be necessary.
+- Alternatively, on the system where the core file was produced, you can use `jpackcore` to collect all the relevant files into a single zip archive. That archive can be unpacked, possibly on another system, into a new, empty directory. Running `jdmpview` in that new directory (where the core file will be located) should enable it to find all the data it needs, including information that might not be included in the core file itself, such as symbols or sections. When you use an archive produced by `jpackcore`, setting the path or library mapping system properties should not be necessary.
 
 On z/OS&reg;, you can copy the dump to an HFS file and supply that as input to `jdmpview`, or you can supply a fully qualified MVS&trade; data set name. For example:
 

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -22,26 +22,28 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# Dump extractor (`jextract`)
+# Dump extractor (`jpackcore`)
 
 **(AIX&reg;, Linux&reg;, macOS&reg;)**
 
-On some operating systems, copies of executable files and libraries are required for a full analysis of a core dump (you can get some information from the dump without these files, but not as much). Run the `jextract` utility to collect these extra files and package them into an archive file along with the core dump. To analyze the output, use the [dump viewer (`jdmpview`)](tool_jdmpview.md).
+On some operating systems, copies of executable files and libraries are required for a full analysis of a core dump (you can get some information from the dump without these files, but not as much). Run the `jpackcore` utility to collect these extra files and package them into an archive file along with the core dump. To analyze the output, use the [dump viewer (`jdmpview`)](tool_jdmpview.md).
+
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** This tool replaces `jextract`, which is deprecated in OpenJ9 version 0.26.0.
 
 ## Syntax
 
-        jextract [-r] <core file name> [<zip_file>]
+        jpackcore [-r] <core file name> [<zip_file>]
 
 where:
 
-- `-r` forces the `jextract` utility to proceed when the system dump is created from an SDK with a different build ID. See **Restriction**.
+- `-r` forces the `jpackcore` utility to proceed when the system dump is created from an SDK with a different build ID. See **Restriction**.
 - `<core file name>` is the name of the system dump.
 - `<zip_file>` is the name you want to give to the processed file. If you do not specify a name, output is written to `<core file name>.zip` by default. The output is written to the same directory as the core file.
 
-:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** You should run `jextract` on the same system that produced the system dump in order to collect the correct executables and libraries referenced in the system dump. You should also run `jextract` using the same VM level, to avoid any problems. From Eclipse OpenJ9 V0.24.0, the utility always checks that the build ID of the SDK that created the dump file matches the `jextract` build ID. Where these IDs do not match, the following exception is thrown:
+:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** You should run `jpackcore` on the same system that produced the system dump in order to collect the correct executables and libraries referenced in the system dump. You should also run `jpackcore` using the same VM level, to avoid any problems. From Eclipse OpenJ9 V0.24.0, the utility always checks that the build ID of the SDK that created the dump file matches the `jpackcore` build ID. Where these IDs do not match, the following exception is thrown:
 
 ```  
-J9RAS.buildID is incorrect (found XXX, expecting YYY). This version of jextract is incompatible with this dump (use '-r' option to relax this check).
+J9RAS.buildID is incorrect (found XXX, expecting YYY). This version of jpackcore is incompatible with this dump (use '-r' option to relax this check).
 ```
 
 To continue, despite the mismatch, use the `-r` option.

--- a/docs/version0.26.md
+++ b/docs/version0.26.md
@@ -27,6 +27,7 @@
 The following new features and notable changes since v 0.25.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Dump extractor tool deprecated](#dump-extractor-tool-deprecated)
 
 
 ## Features and changes
@@ -38,6 +39,13 @@ OpenJ9 release 0.26.0 supports OpenJDK 8, 11, and 16.
 For OpenJDK 8 and 11 builds that contain OpenJ9, see [Version 0.25.0](version0.25.md) for additional changes that have now been fully tested for these versions.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Dump extractor tool deprecated
+
+The dump extractor tool, `jextract`, is deprecated in this release and replaced with the `jpackcore` tool. This tool uses the same syntax and parameters as `jextract` to collect diagnostic files for analysis. The change is necessary because the reference implementation will be introducing a tool in a future release that is also called `jextract`.
+
+For more information, see [Dump extractor](tool_jextract.md).
+
 
 ## Full release information
 


### PR DESCRIPTION
- Added info to the release topic about deprecating jextract
- Changed the references in the jextract topic to jpackcore, including a note about jextract deprecation
- Found and updated other references to jextract in the docs.

Closes: #767

Signed-off-by: SueChaplain <sue_chaplain@uk.ibm.com>