### PR TITLE
Excessive GC

### DIFF
--- a/docs/xenableexcessivegc.md
+++ b/docs/xenableexcessivegc.md
@@ -28,7 +28,7 @@ Enables or disables the throwing of an `OutOfMemory` exception if excessive time
 
 If excessive time is spent in the GC, the option returns `null` for an allocate request and thus causes an `OutOfMemory` exception to be thrown.
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The `OutOfMemory` exception is thrown only when the heap has been fully expanded and the percentage of application run time that is not spent in garbage collection is at least 95%. This percentage is the default value that triggers an excessive GC event. You can control this value with the [`-Xgc:excessiveGCratio`](xgc.md#excessivegcratio) option.
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The `OutOfMemory` exception is thrown only when the heap has been fully expanded and the percentage of application run time that is spent in garbage collection is at least 95%. This percentage is the default value that triggers an excessive GC event. You can control this value with the [`-Xgc:excessiveGCratio`](xgc.md#excessivegcratio) option.
 
 ## Syntax
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -158,9 +158,9 @@ Options that change the behavior of the garbage collector.
   |---------------|----------------|-----------------------|
   | `<value>`     | [percentage]   | 95                    |
 
-: where `<value>` is a percentage of total application run time that is not spent in GC.
+: where `<value>` is a percentage of total application run time that is spent in GC.
 
-    The default value is 95, which means that anything over 5% of total application run time spent on GC is deemed excessive. This option can be used only when [`-Xenableexcessivegc`](xenableexcessivegc.md) is set (enabled by default).
+    The default value is 95, which means that anything over 95% of total application run time spent on GC is deemed excessive. This option can be used only when [`-Xenableexcessivegc`](xenableexcessivegc.md) is set (enabled by default).
 
 : This option can be used with all OpenJ9 GC policies.
 


### PR DESCRIPTION
The logic is reversed. Removing 'not'.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>