### PR TITLE
Document Offheap

### DIFF
--- a/docs/version0.53.md
+++ b/docs/version0.53.md
@@ -28,6 +28,7 @@ The following new features and notable changes since version 0.51.0 are included
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [OpenSSL support added for PBKDF2 algorithm](#openssl-support-added-for-pbkdf2-algorithm)
 - [OpenSSL 3.5.1 is bundled on all platforms](#openssl-351-is-bundled-on-all-platforms)
+- [Offheap support is added for the `balanced` GC policy](#offheap-support-is-added-for-the-balanced-gc-policy)
 
 ## Features and changes
 
@@ -47,7 +48,13 @@ OpenSSL native cryptographic support is added for the Password based key derivat
 
 OpenSSL 3.5.1 is now supported and bundled on all platforms. You can use the `jdk.native.openssl.skipBundled` property to specify whether to load the pre-packaged OpenSSL library or the library available on the system path.
 
-For more informaiton, see [OpenSSL](openssl.md).
+For more information, see [OpenSSL](openssl.md).
+
+### Offheap support is added for the `balanced` GC policy
+
+Before the 0.53.0 release, the `balanced` GC policy used an arraylet representation in the heap to support large arrays that cannot be contained in a region. Now, if the array's data are larger than a region size, the data are stored into a separate area, Offheap.
+
+For more information, see [GC processing](gc.md#balanced-policy).
 
 ## Known problems and full release information
 

--- a/docs/vgclog.md
+++ b/docs/vgclog.md
@@ -49,7 +49,12 @@ The verbose GC logs are printed in XML format and consist of the following secti
 
 - A summary of your GC configuration, which is captured in the `<initialized>` XML element.
 
-- Information about the GC cycles that ran, including GC operations and GC increments.  
+- Information about the GC cycles that ran, including GC operations and GC increments.
+
+From the 0.53.0 release onwards, while running the balanced GC, the verbose GC logs include the following information:
+
+- The `<initialized>` XML element will indicate that Offheap is used and how large it is.
+- Each GC cycle will show how many Offheap live objects there are at GC start, how many have been allocated since the previous GC, how many have died this cycle, and how many live are left at GC end.
 
 For definitions of GC cycles and operations, see [Garbage collection](gc_overview.md). For definitions of GC increments, see [GC increments and interleaving](#gc-increments-and-interleaving).
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1540

Offheap support added to the balanced gc policy

Closes #1540
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com