### PR TITLE
Fix documentation error for method specification

### DIFF
--- a/docs/xtrace.md
+++ b/docs/xtrace.md
@@ -593,7 +593,7 @@ To specify one or more method specifications, use the following syntax:
 
 The syntax for `<method_specification>` can be further broken down to the following suboptions:
 
-    -Xtrace:methods={[!][*][<package>/]<class>[*],[[*]<method>[*]|[()]]}
+    -Xtrace:methods={[!][*][<package>/]<class>[*].[[*]<method>[*]|[()]]}
 
 Where:
 


### PR DESCRIPTION
The separator between class name and method name is "." not ",". Like in the example below, it is "java/lang/String.substring"

Fixes #1565