### PR TITLE
Requirement..txt update - super-collections

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -111,7 +111,7 @@ requests==2.32.4
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil
-super-collections==0.5.0
+super-collections==0.5.7
     # via mkdocs-macros-plugin
 termcolor==2.2.0
     # via mkdocs-macros-plugin


### PR DESCRIPTION
To bump mkdocs-macros-plugin from 1.3.7 to 1.4.0 as per https://github.com/eclipse-openj9/openj9-docs/pull/1590, super-collections must be >=0.5.7.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com