### PR TITLE
Update supported JFR events

### DIFF
--- a/docs/version0.56.md
+++ b/docs/version0.56.md
@@ -28,6 +28,7 @@ The following new features and notable changes since version 0.55.0 are included
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Change in the `getCpuLoad()` method return value based on the platform](#change-in-the-getcpuload-method-return-value-based-on-the-platform)
 - [New `-Xgc` parameters related to macro fragmentation added](#new-xgc-parameters-related-to-macro-fragmentation-added)
+- ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png)[The NativeLibrary and SystemProcess JFR events are supported in all platforms except z/OS](#the-nativelibrary-and-systemprocess-jfr-events-are-supported-in-all-platforms-except-zos) ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
 
 ## Features and changes
 
@@ -50,6 +51,14 @@ For more information, see [`-XX:[+|-]CpuLoadCompatibility`](xxcpuloadcompatibili
 New parameters, `enableEstimateFragmentation` and `disableEstimateFragmentation` are added to the `-Xgc` option. You can use these options to control the calculating and reporting of the estimates of the macro fragmentation, as reported by verbose garbage collection (GC) at the end of Scavenge GCs.
 
 For more information, see [`-Xgc`](xgc.md#disableestimatefragmentation).
+
+### ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) The NativeLibrary and SystemProcess JFR events are supported in all platforms except z/OS
+
+From this release onwards, the NativeLibrary and SystemProcess JFR events are supported in all platforms except z/OS. Earlier, these JFR events were supported only in Linux&reg;.
+
+To record and analyze the SystemProcess JFR event on z/OS (2.5 and 3.1), you must install [APAR OA62757](https://www.ibm.com/support/pages/apar/OA62757).
+
+For more information, see [`-XX:[+|-]FlightRecorder`](xxflightrecorder.md). ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
 
 ## Known problems and full release information
 

--- a/docs/xxflightrecorder.md
+++ b/docs/xxflightrecorder.md
@@ -80,11 +80,11 @@ All JFR-related `jcmd` options might change in future releases.
 - ModuleRequires
 - MonitorEnter
 - MonitorWait
-- NativeLibrary (Linux&reg; only)
+- NativeLibrary (except z/OS)
 - OSInformation
 - PhysicalMemory
 - SystemGC
-- SystemProcess (Linux only)
+- SystemProcess (except z/OS)
 - ThreadContextSwitchRate
 - ThreadCPULoad (except z/OS)
 - ThreadDump
@@ -97,6 +97,8 @@ All JFR-related `jcmd` options might change in future releases.
 - YoungGenerationConfig
 
 ```
+  :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** To record and analyze the SystemProcess JFR event on z/OS (2.5 and 3.1), you must install [APAR OA62757](https://www.ibm.com/support/pages/apar/OA62757).
+
 - Support for the following capabilities is not available:
 
     - `-XX:StartFlightRecording` and `-XX:FlightRecorderOptions`
@@ -106,7 +108,7 @@ All JFR-related `jcmd` options might change in future releases.
 
 Support for JFR will be expanded in future releases.
 
-![End of content that applies to Java 11 (LTS) and later](cr/java_close.png)
+![End of content that applies to Java 11 (LTS) and later](cr/java_close_lts.png)
 
 ## See Also
 
@@ -114,6 +116,7 @@ Support for JFR will be expanded in future releases.
 - [What's new in version 0.51.0](version0.51.md#support-for-jdk-flight-recorder-jfr-in-the-vm-for-openjdk-11-and-later-running-on-all-platforms)
 - [What's new in version 0.53.0](version0.53.md#new-java-flight-recorder-jfr-events-are-added-in-this-release)
 - [What's new in version 0.54.0](version0.54.md#new-jdk-flight-recorder-jfr-events-are-added-in-this-release)
+- [What's new in version 0.56.0](version0.56.md#the-nativelibrary-and-systemprocess-jfr-events-are-supported-in-all-platforms-except-zos)
 
 
 <!-- ==== END OF TOPIC ==== xxflightrecorder.md ==== -->


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1609

Starting in 0.56, NativeLibrary and SystemProcess are supported in all platforms except z/OS.

Closes #1609
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com