### PR TITLE
OpenJDK 25 features are applicable to 25 not 24

### DIFF
--- a/docs/version0.55.md
+++ b/docs/version0.55.md
@@ -69,7 +69,7 @@ The following features are supported by OpenJ9:
 
 - [JEP 508](https://openjdk.java.net/jeps/508): Vector API (Tenth Incubator)
 
-The following features are implemented in OpenJDK and available in any build of OpenJDK 24 with OpenJ9:
+The following features are implemented in OpenJDK and available in any build of OpenJDK 25 with OpenJ9:
 
 - [JEP 470](https://openjdk.java.net/jeps/470): PEM Encodings of Cryptographic Objects (Preview)
 - [JEP 502](https://openjdk.java.net/jeps/502): Stable Values (Preview)


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1615

Corrected the version number.

Closes #1615
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com