### PR TITLE
Format of the java.vm.version system property

### DIFF
--- a/docs/version0.56.md
+++ b/docs/version0.56.md
@@ -29,6 +29,7 @@ The following new features and notable changes since version 0.55.0 are included
 - [Change in the `getCpuLoad()` method return value based on the platform](#change-in-the-getcpuload-method-return-value-based-on-the-platform)
 - [New `-Xgc` parameters related to macro fragmentation added](#new-xgc-parameters-related-to-macro-fragmentation-added)
 - ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png)[The NativeLibrary and SystemProcess JFR events are supported in all platforms except z/OS](#the-nativelibrary-and-systemprocess-jfr-events-are-supported-in-all-platforms-except-zos) ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
+- [The format of the `java.vm.version` system property value is updated to be compatible with the Runtime.Version parser](#the-format-of-the-javavmversion-system-property-value-is-updated-to-be-compatible-with-the-runtimeversion-parser)
 
 ## Features and changes
 
@@ -59,6 +60,22 @@ From this release onwards, the NativeLibrary and SystemProcess JFR events are su
 To record and analyze the SystemProcess JFR event on z/OS (2.5 and 3.1), you must install [APAR OA62757](https://www.ibm.com/support/pages/apar/OA62757).
 
 For more information, see [`-XX:[+|-]FlightRecorder`](xxflightrecorder.md). ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
+
+### The format of the `java.vm.version` system property value is updated to be compatible with the Runtime.Version parser
+
+The format of the `java.vm.version` system property value is modified from the previous releases. This change was initiated in the 0.55.0 release and it affects 0.56.0 and all future releases.
+
+The new format of the value is standardized and structured and is parse-able by the `java.lang.Runtime.Version` class. This modification also changes the `-version` output. For example, `build openj9-0.56.0` changes to `build 11.0.29+7-openj9-0.56.0`. The OpenJ9 version, `openj9-0.56.0` in the example, is at the end of the optional component.
+
+With this new structured format, the `java.lang.Runtime.Version` class parses the value and you can extract specific information such as the information related to the VM version. For example, following information can be extracted from `java.vm.version = 11.0.29+7-openj9-0.56.0`:
+
+- `11.0.29` - Feature version of the OpenJDK
+- `7` - Build number of the OpenJDK
+- `openj9-0.56.0` - Additional build information
+
+This also applies to the z/OS releases. For example, `z/OS-Release-17.0.16.0-b01` is changed to `17.0.17+10-zOS-Release-17.0.17.0-b01`.
+
+For more information, see [Class Runtime.Version](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/Runtime.Version.html).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1617

Added the change in the format of the java.vm.version system property in 0.56.0 What's new topic.

Closes #1617
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com