### PR TITLE
Use pip 25.2 until pip 25.3 is compatible with pep517

### DIFF
--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 python3
     && rm -rf /var/lib/apt/lists/* \
     && sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd \
     && mkdir -p /var/run/sshd \
-    && pip3 install -U pip \
     && pip3 install virtualenv \
     && virtualenv myenv -p python3
 # Update LANG to fix error with pip-tools
@@ -39,7 +38,7 @@ ENV LANG=C.UTF-8
 # Update path to include the virtual env install location
 ENV PATH /myenv/bin:$PATH
 # Activate the virtualenv environment, install build and test tools, create a new dependency list, and change permissions to ensure that Jenkins modify packages where necessary
-RUN /bin/bash -c "source /myenv/bin/activate && pip3 install setuptools pip-tools && pip3 install --requirement /tmp/requirements.txt && mv /tmp/requirements.txt /tmp/requirements.orig && pip-compile /tmp/requirements.in && chmod -R ugo+w /myenv"
+RUN /bin/bash -c "source /myenv/bin/activate && pip3 install 'pip<25.3' pip-tools setuptools && pip3 install --requirement /tmp/requirements.txt && mv /tmp/requirements.txt /tmp/requirements.orig && pip-compile /tmp/requirements.in && chmod -R ugo+w /myenv"
 # Setup jenkins user
 RUN  useradd -m -d /home/jenkins -s /bin/sh jenkins \
     && echo "jenkins:jenkinspass" | chpasswd \


### PR DESCRIPTION
Issues
https://github.com/eclipse-openj9/openj9-docs/pull/1621#issuecomment-3481614431
https://github.com/jazzband/pip-tools/issues/2252

With this change I can successfully build the image.
`Successfully tagged localhost/ibmjavaid/mkdocs_test_env:latest`