### PR TITLE
Update Requirements.txt

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -73,7 +73,7 @@ mkdocs-material==9.6.23
     # via -r requirements.in
 mkdocs-material-extensions==1.3
     # via mkdocs-material
-packaging==24.0
+packaging==24.2
     # via
     #   mkdocs
     #   mkdocs-macros-plugin
@@ -83,7 +83,7 @@ pathspec==0.11.1
     # via
     #   mkdocs
     #   mkdocs-macros-plugin
-platformdirs==3.9.1
+platformdirs==4.3.6
     # via mkdocs-get-deps
 pygments==2.16.1
     # via mkdocs-material


### PR DESCRIPTION
Pip's dependency conflict resolution. findpython 0.7.0 requires platformdirs>=4.3.6 instead of platformdirs 3.9.1 which is incompatible. poetry 2.2.1 requires packaging>=24.2, instead of packaging 24.0 which is incompatible.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com