### PR TITLE
Update Requirements.txt - certifi 2025.10.5

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -26,7 +26,7 @@ babel==2.12.1
     # via mkdocs-material
 backrefs==5.8
     # via mkdocs-material
-certifi==2025.6.15
+certifi==2025.10.5
     # via requests
 charset-normalizer==2.1.1
     # via requests


### PR DESCRIPTION
Selenium 4.38.0 requires certifi>=2025.10.5, but it has certifi 2025.6.15 which is incompatible. Updated the Requirements.txt  accordingly.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com