### PR TITLE
Update java.lang.string.substring.nocopy

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -97,7 +97,7 @@ You can set the following options to make OpenJ9 behave in the same way as HotSp
 
 | Option                                      | Usage                                                           |
 |---------------------------------------------|-----------------------------------------------------------------|
-| ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) [`-Djava.lang.string.substring.nocopy=true`](djavalangstringsubstringnocopy.md) |  Avoid String sharing by `String.substring()`. |
+| ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) [`-Djava.lang.string.substring.nocopy=true`](djavalangstringsubstringnocopy.md) |  Avoid String sharing by `String.substring()`. ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close_lts.png)|
 | [`-Xnuma:none`](xnumanone.md)               | Disable non-uniform memory architecture (NUMA) awareness.       |
 | [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md)    | Force handling of SIGABRT signals to be compatible with HotSpot. |
 

--- a/docs/djavalangstringsubstringnocopy.md
+++ b/docs/djavalangstringsubstringnocopy.md
@@ -23,9 +23,9 @@
 
 # -Djava.lang.string.substring.nocopy
 
-:fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Restriction:** This system property is supported only on Java&trade; 8. String sharing cannot be enabled on Java 11 and later.
+:fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Restriction:** This system property is supported only on Java&trade; 8 and Java 11. String sharing cannot be enabled on Java 17 and later.
 
-![Start of content that applies only to Java 8 (LTS)](cr/java8.png) Setting this property to `true` avoids sharing a String object when substring() is used to subset a String beginning from offset zero. Avoiding sharing is compatible with the Oracle HotSpot VM.
+![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) Setting this property to `true` avoids sharing a String object when substring() is used to subset a String beginning from offset zero. Avoiding sharing is compatible with the Oracle HotSpot VM. ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close_lts.png)
 
 ## Syntax
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1654

Added icon to indicate that this option is applicable to JDK 11 also.

Closes #1654
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com