### PR TITLE
Document new -XX:[+/-]UseMediumPageSize

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -183,6 +183,9 @@ The following example sets 4 KB for text and 64 KB for stack, native data, and h
 ```
 LDR_CNTRL=TEXTPSIZE=4K@STACKPSIZE=64K@DATAPSIZE=64K
 ```
+On AIX systems, the `LDR_CNTRL` environment variable is set to `TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K` by default to specify medium page sizes (64K) for the text, data, stack, and shared memory segments to improve performance.
+
+From the 0.59.0 release onwards, you can use the `-XX:-UseMediumPageSize` option to disable this default setting of the `LDR_CNTRL` environment variable. For more information, see [`-XX:[+|-]UseMediumPageSize`](xxusemediumpagesize.md).
 
 For more information, including support considerations, see [Large pages](https://www.ibm.com/support/knowledgecenter/ssw_aix_72/performance/large_page_ovw.html) and [Multiple page size support](https://www.ibm.com/support/knowledgecenter/ssw_aix_72/performance/multiple_page_size_support.html) in the AIX documentation.
 

--- a/docs/version0.59.md
+++ b/docs/version0.59.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2026 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.59.0
+
+The following new features and notable changes since version 0.58.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [New `-XX:[+|-]UseMediumPageSize` option is added](#new-xx-usemediumpagesize-option-is-added)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.59.0 supports OpenJDK 8, 11, 17, 21, 25, and 26.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### New `-XX:[+|-]UseMediumPageSize` option is added
+
+With the new option, `-XX:-UseMediumPageSize `, you can now disable the default setting of the `LDR_CNTRL` environment variable whereby medium page sizes (64 KB) are configured for text, data, stack, and shared memory segments.
+
+For more information, see [`-XX:[+|-]UseMediumPageSize`](xxusemediumpagesize.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.58.0 and v0.59.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.59/0.59.md).
+
+<!-- ==== END OF TOPIC ==== version0.59.md ==== -->

--- a/docs/xxusemediumpagesize.md
+++ b/docs/xxusemediumpagesize.md
@@ -1,0 +1,53 @@
+﻿<!--
+* Copyright (c) 2017, 2026 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -XX:[+|-]UseMediumPageSize
+
+**AIX only**
+
+This option is used to enable or disable the default definition setting of the `LDR_CNTRL` environment variable.
+
+## Syntax
+
+        -XX:[+|-]UseMediumPageSize
+
+| Setting                      | Effect  | Default                                                                        |
+|------------------------------|---------|:------------------------------------------------------------------------------:|
+| `-XX:+UseMediumPageSize` | Enable  |      :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>    |
+| `-XX:-UseMediumPageSize` | Disable |                                                                           |
+
+## Explanation
+
+On AIX systems, by default the Java launcher sets the `LDR_CNTRL` environment variable as `TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K` to specify medium page sizes (64 KB) for the text, data, stack, and shared memory segments. This default setting is used to improve performance.
+
+You can use `-XX:-UseMediumPageSize` to disable the default setting of the `LDR_CNTRL` environment variable. When this option is used, the Java launcher uses the default AIX page sizes (4 KB for each segment).
+
+You can re-enable the default setting with the `-XX:+UseMediumPageSize` option.
+
+## See also
+
+- [What's new in version 0.59.0](version0.59.md#new-xx-usemediumpagesize-option-is-added)
+- [Configuring your systems](configuring.md#aix-systems)
+- [-Xlp:codecache](xlpcodecache.md#aix)
+
+<!-- ==== END OF TOPIC ==== xxusemediumpagesize.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.59.0"                                                       : version0.59.md
         - "Version 0.58.0"                                                       : version0.58.md
         - "Version 0.57.0"                                                       : version0.57.md
         - "Version 0.56.0"                                                       : version0.56.md
@@ -473,6 +474,7 @@ nav:
             - "-XX:[+|-]UseDebugLocalMap"                                        : xxdebuglocalmap.md
             - "-XX:[+|-]UseGCStartupHints"                                       : xxusegcstartuphints.md
             - "-XX:[+|-]UseJITServer"                                            : xxusejitserver.md
+            - "-XX:[+|-]UseMediumPageSize"                                       : xxusemediumpagesize.md
             - "-XX:[+|-]UseNoGC"                                                 : xxusenogc.md
             - "-XX:[+|-]UseZlibNX"                                               : xxusezlibnx.md
             - "-XX:[+|-]UTFCache"                                                : xxutfcache.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1678

Documented the new option -XX:[+|-]UseMediumPageSize. Created the What's new topic and updated mkdocs.yml file. Updated the related topics.

Closes #1678
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com