### PR TITLE
p, x, z Linux are compiled with gcc 14.2

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -77,13 +77,9 @@ OpenJDK 8 binaries are expected to function on the minimum operating system leve
 | Ubuntu 22.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Ubuntu 24.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
 
-- Not all of these distributions are tested, but the following distributions are expected to function without problems:
-
-    - Linux distributions that have a minimum glibc version 2.12 (x) or 2.17 (others)
-
-- Support for OpenJ9 on CentOS 6.10 is removed from 0.46.0 release onwards. With the removal of support, the minimum glibc version (x) might change in future releases.
+    - Linux distributions that have a minimum glibc version 2.17
 
 | Windows&trade;                              | x32                                                                                  |  x64                                                                                 |
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
@@ -118,13 +114,9 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 | Ubuntu 22.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Ubuntu 24.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
 
-- Not all of these distributions are tested, but the following distributions are expected to function without problems:
-
-    - Linux distributions that have a minimum glibc version 2.12 (x) or 2.17 (others)
-
-- Support for OpenJ9 on CentOS 6.10 is removed from 0.46.0 release onwards. With the removal of support, the minimum glibc version (x) might change in future releases.
+    - Linux distributions that have a minimum glibc version 2.17
 
 | Windows                                   | x64                                                                                  |
 |-------------------------------------------|--------------------------------------------------------------------------------------|
@@ -161,7 +153,7 @@ OpenJDK 17 binaries are expected to function on the minimum operating system lev
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
 
-- Linux distributions that have a minimum glibc version 2.17
+    - Linux distributions that have a minimum glibc version 2.17
 
 | Windows                                   | x64                                                                                  |
 |-------------------------------------------|--------------------------------------------------------------------------------------|
@@ -198,7 +190,7 @@ OpenJDK 21 binaries are expected to function on the minimum operating system lev
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
 
-- Linux distributions that have a minimum glibc version 2.17
+    - Linux distributions that have a minimum glibc version 2.17
 
 | Windows                                   | x64                                                                                  |
 |-------------------------------------------|--------------------------------------------------------------------------------------|
@@ -236,7 +228,7 @@ OpenJDK 25 and later binaries are expected to function on the minimum operating 
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
 
-- Linux distributions that have a minimum glibc version 2.17
+    - Linux distributions that have a minimum glibc version 2.17
 
 | Windows                                   | x64                                                                                  |
 |-------------------------------------------|--------------------------------------------------------------------------------------|
@@ -267,9 +259,9 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 6.10            | gcc 11.2                              |
-| Linux on POWER&reg; LE 64-bit | CentOS 7.9             | gcc 11.2                              |
-| Linux on IBM Z&reg; 64-bit    | RHEL 7.9               | gcc 11.2                              |
+| Linux x86 64-bit              | CentOS 6.10            | gcc 14.2                              |
+| Linux on POWER&reg; LE 64-bit | CentOS 7.9             | gcc 14.2                              |
+| Linux on IBM Z&reg; 64-bit    | RHEL 7.9               | gcc 14.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
 | Windows x86 32-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
@@ -280,9 +272,9 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 6.10            | gcc 11.2                              |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
+| Linux x86 64-bit              | CentOS 6.10            | gcc 14.2                              |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
@@ -293,9 +285,9 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 7.9             | gcc 11.2                              |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
+| Linux x86 64-bit              | CentOS 7.9             | gcc 14.2                              |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
@@ -306,9 +298,9 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 7.9             | gcc 11.2                              |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
+| Linux x86 64-bit              | CentOS 7.9             | gcc 14.2                              |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
@@ -319,9 +311,9 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 7.9             | gcc 11.2                              |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
+| Linux x86 64-bit              | CentOS 7.9             | gcc 14.2                              |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |

--- a/docs/version0.59.md
+++ b/docs/version0.59.md
@@ -28,6 +28,8 @@ The following new features and notable changes since version 0.58.0 are included
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [New `-XX:[+|-]UseMediumPageSize` option is added](#new-xx-usemediumpagesize-option-is-added)
 - [A signal handler optimization feature that was disabled on Windows&trade; is enabled again](#a-signal-handler-optimization-feature-that-was-disabled-on-windows-is-enabled-again)
+- [Compiler changes for Linux&reg;](#compiler-changes-for-linux)
+- ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) [glibc version is changed to 2.17 on Linux x86 64-bit builds for OpenJDK 8 and 11](#glibc-version-is-changed-to-217-on-linux-x86-64-bit-builds-for-openjdk-8-and-11) ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close_lts.png)
 
 ## Features and changes
 
@@ -48,6 +50,16 @@ For more information, see [`-XX:[+|-]UseMediumPageSize`](xxusemediumpagesize.md)
 In the [0.57.0 release](version0.57.md#a-signal-handler-optimization-feature-is-temporarily-disabled), on the Windows platform, a signal handler optimization feature was temporarily disabled by default. The feature was disabled because VM crashes were suspected to be related to an interaction between the Windows control flow guard feature and the VM's signal handling mechanism.
 
 Now the root cause for these VM crashes has been identified and fixed. Therefore, in this release, the disabled signal handler optimization feature is enabled again.
+
+### Compiler changes for Linux
+
+Linux x86 64-bit, Linux on POWER&reg; LE 64-bit, and Linux on IBM Z&reg; 64-bit builds on all OpenJDK versions now use the gcc 14.2 compiler.
+
+For more information, see [Supported environments](openj9_support.md).
+
+### ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) glibc version is changed to 2.17 on Linux x86 64-bit builds for OpenJDK 8 and 11
+
+For OpenJDK versions 8 and 11, Linux x86 64-bit is now compiled on CentOS 7, modifying the minimum glibc version to 2.17 from 2.12. The VM will fail to start on CentOS 6 from this release onwards. ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close.png)
 
 ## Known problems and full release information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -471,7 +471,7 @@ nav:
             - "-XX:[+|-]TransparentHugePage"                                     : xxtransparenthugepage.md
             - "-XX:[+|-]UseCompressedOops"                                       : xxusecompressedoops.md
             - "-XX:[+|-]UseContainerSupport"                                     : xxusecontainersupport.md
-            - "-XX:[+|-]UseDebugLocalMap"                                        : xxdebuglocalmap.md
+            - "-XX:[+|-]UseDebugLocalMap"                                        : xxusedebuglocalmap.md
             - "-XX:[+|-]UseGCStartupHints"                                       : xxusegcstartuphints.md
             - "-XX:[+|-]UseJITServer"                                            : xxusejitserver.md
             - "-XX:[+|-]UseMediumPageSize"                                       : xxusemediumpagesize.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1679

Updated the supported environments topic.

Closes #1679
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com