### PR TITLE
-XX:StartFlightRecording

### DIFF
--- a/docs/version0.49.md
+++ b/docs/version0.49.md
@@ -71,7 +71,7 @@ For more information, see [Compressed references](allocation.md#compressed-refer
 
 This release supports, as a technical preview, JDK Flight Recorder (JFR) that is available for OpenJDK 11 and later running on Linux&reg; x86 and Linux on AArch64 only.
 
-You can collect profiling and diagnostic information with JFR. You can enable or disable JFR in the VM with the [`-XX:[+|-]FlightRecorder`](xxflightrecorder.md) option. ![End of content that applies only to Java 11 and later](cr/java_close.png)
+You can collect profiling and diagnostic information with JFR. You can enable or disable JFR in the VM with the [`-XX:[+|-]FlightRecorder`](xxflightrecorder.md) option. ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
 
 ## Known problems and full release information
 

--- a/docs/version0.59.md
+++ b/docs/version0.59.md
@@ -30,6 +30,7 @@ The following new features and notable changes since version 0.58.0 are included
 - [A signal handler optimization feature that was disabled on Windows&trade; is enabled again](#a-signal-handler-optimization-feature-that-was-disabled-on-windows-is-enabled-again)
 - [Compiler changes for Linux&reg;](#compiler-changes-for-linux)
 - ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) [glibc version is changed to 2.17 on Linux x86 64-bit builds for OpenJDK 8 and 11](#glibc-version-is-changed-to-217-on-linux-x86-64-bit-builds-for-openjdk-8-and-11) ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close_lts.png)
+- ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) [New `-XX:StartFlightRecording` command-line option is added](#new-xxstartflightrecording-command-line-option-is-added) ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close_lts.png)
 
 ## Features and changes
 
@@ -60,6 +61,16 @@ For more information, see [Supported environments](openj9_support.md).
 ### ![Start of content that applies to Java 8 (LTS)](cr/java8.png) ![Start of content that applies to Java 11 (LTS)](cr/java11.png) glibc version is changed to 2.17 on Linux x86 64-bit builds for OpenJDK 8 and 11
 
 For OpenJDK versions 8 and 11, Linux x86 64-bit is now compiled on CentOS 7, modifying the minimum glibc version to 2.17 from 2.12. The VM will fail to start on CentOS 6 from this release onwards. ![End of content that applies to Java 8 and 11 (LTS)](cr/java_close.png)
+
+### ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) New `-XX:StartFlightRecording` command-line option is added
+
+Support for the `-XX:StartFlightRecording` command-line option is now available from this release onwards. Instead of the JDK Flight Recorder (JFR)-related `jcmd` option, you can now use the `-XX:StartFlightRecording` command-line option to start the JFR recording in the VM.
+
+The `-XX:StartFlightRecording` command-line option cannot be used simultaneously with JFR-related `jcmd` options.
+
+For more information, see [`-XX:StartFlightRecording`](xxstartflightrecording.md).
+
+ ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
 
 ## Known problems and full release information
 

--- a/docs/xxflightrecorder.md
+++ b/docs/xxflightrecorder.md
@@ -38,7 +38,7 @@
 
 ## Explanation
 
-If JFR is enabled in the VM with the `-XX:+FlightRecorder` option, then you can trigger profile and diagnostic recording with the [`jcmd`](https://eclipse.dev/openj9/docs/tool_jcmd/) tool. Recording does not start automatically, it must be triggered.
+If JFR is enabled in the VM with the `-XX:+FlightRecorder` option, then you can trigger profile and diagnostic recording with either the [`jcmd`](https://eclipse.dev/openj9/docs/tool_jcmd/) tool or the [`-XX:StartFlightRecording`](xxstartflightrecording.md) command-line option. Recording does not start automatically, it must be triggered.
 
 To start a recording, specify the following `jcmd` option command:
 
@@ -106,9 +106,11 @@ All JFR-related `jcmd` options might change in future releases.
 ```
   :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** To record and analyze the SystemProcess JFR event on z/OS (2.5 and 3.1), you must install [APAR OA62757](https://www.ibm.com/support/pages/apar/OA62757).
 
+- Support for the `-XX:StartFlightRecording` capability was made available in the 0.59.0 release.
+
 - Support for the following capabilities is not available:
 
-    - `-XX:StartFlightRecording` and `-XX:FlightRecorderOptions`
+    - `-XX:FlightRecorderOptions`
     - JFR APIs (`jdk/jfr/*`classes)
     - Controlling JFR with Java Management Extensions (JMX)
     - JFR streaming
@@ -125,6 +127,8 @@ Support for JFR will be expanded in future releases.
 - [What's new in version 0.53.0](version0.53.md#new-java-flight-recorder-jfr-events-are-added-in-this-release)
 - [What's new in version 0.54.0](version0.54.md#new-jdk-flight-recorder-jfr-events-are-added-in-this-release)
 - [What's new in version 0.56.0](version0.56.md#the-nativelibrary-and-systemprocess-jfr-events-are-supported-in-all-platforms-except-zos)
+- [What's new in version 0.59.0](version0.59.md#new-xxstartflightrecording-command-line-option-is-added)
+- [-XX:StartFlightRecording](xxstartflightrecording.md)
 
 
 <!-- ==== END OF TOPIC ==== xxflightrecorder.md ==== -->

--- a/docs/xxstartflightrecording.md
+++ b/docs/xxstartflightrecording.md
@@ -1,0 +1,66 @@
+<!--
+* Copyright (c) 2017, 2026 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -XX:StartFlightRecording
+
+![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) This command-line option starts the JDK Flight Recorder (JFR) recording in the VM. JFR is a built-in profiling and troubleshooting feature in the VM that is used to collect profiling and diagnostic information.
+
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
+
+- JFR recording can also be enabled or disabled on OpenJ9 by using the `jcmd` options as explained in the [-XX:[+|-]FlightRecorder](xxflightrecorder.md#explanation) topic. The JDK Mission Control (JMC) tool is the only way to view the produced JFR file.
+- The command-line option cannot be used simultaneously with JFR-related `jcmd` options.
+
+## Syntax
+
+        -XX:StartFlightRecording[[=filename=<file_name_with_path>.jfr][,duration=<time_with_unit_of_time>][,delay=<time_with_unit_of_time>]]
+
+where:
+
+- Optional parameters are shown in brackets, [ ].
+
+- `filename=<file_name_with_path>` specifies the name of the file and its location where the recording is saved. The file name should have a `.jfr` extension. If a file name is not specified, the recording is saved in the `defaultJ9recording.jfr` file in the process working directory by default.
+
+- `duration=<time_with_unit_of_time>` specifies the duration of the recording. Units of time are `ns` (nanoseconds), `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), and `d` (days). You can specify only one unit of time, for example, 54s, 12m, 1h, or 2d. If the duration is not specified, the tool continues to record until the VM is shut down.
+
+- `delay=<time_with_unit_of_time>` specifies the delay in the start of the recording. The VM waits for that amount of time before starting the flight recording. Units of time are `ns` (nanoseconds), `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), and `d` (days). You can specify only one unit of time, for example, 54s, 12m, 1h, or 2d. If the delay is not specified, the default value of `0s` is used. The recording then starts immediately when the VM starts.
+
+## Explanation
+
+If JFR is enabled in the VM with the `-XX:+FlightRecorder` option, then you can trigger profile and diagnostic recording with either the `-XX:StartFlightRecording` command-line option or the [`jcmd`](https://eclipse.dev/openj9/docs/tool_jcmd/) tool. Recording does not start automatically, it must be triggered.
+
+Example of the command-line option:
+
+```
+-XX:StartFlightRecording=filename=/path/ABCD.jfr,duration=4s,delay=2s
+```
+
+The recording stops automatically with the `duration` parameter or when the VM stops.
+
+![End of content that applies to Java 11 (LTS) and later](cr/java_close_lts.png)
+
+## See Also
+
+- [What's new in version 0.59.0](version0.59.md#new-xxstartflightrecording-command-line-option-is-added)
+- [`-XX:[+|-]FlightRecorder`](xxflightrecorder.md)
+
+<!-- ==== END OF TOPIC ==== xxstartflightrecording.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -468,6 +468,7 @@ nav:
             - "-XX:[+|-]ShowNativeStackSymbols"                                  : xxshownativestacksymbols.md
             - "-XX:[+|-]ShowUnmountedThreadStacks"                               : xxshowunmountedthreadstacks.md
             - "-XX:-StackTraceInThrowable"                                       : xxstacktraceinthrowable.md
+            - "-XX:StartFlightRecording"                                         : xxstartflightrecording.md
             - "-XX:[+|-]TransparentHugePage"                                     : xxtransparenthugepage.md
             - "-XX:[+|-]UseCompressedOops"                                       : xxusecompressedoops.md
             - "-XX:[+|-]UseContainerSupport"                                     : xxusecontainersupport.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1691

Added the new command-line option `-XX:StartFlightRecording`.

Closes #1691
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com