### PR TITLE
Update Requirements.txt - certifi 2026.1.4

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -26,7 +26,7 @@ babel==2.12.1
     # via mkdocs-material
 backrefs==5.8
     # via mkdocs-material
-certifi==2025.10.5
+certifi==2026.1.4
     # via requests
 charset-normalizer==2.1.1
     # via requests


### PR DESCRIPTION
Selenium 4.43.0 requires certifi>=2026.1.4, instead of certifi 2025.10.5 which is incompatible. Updated the requirements.txt to reflect that.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com