### PR TITLE
AArch64 compiler is updated to gcc 14.2

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -263,7 +263,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux x86 64-bit              | CentOS 6.10            | gcc 14.2                              |
 | Linux on POWER&reg; LE 64-bit | CentOS 7.9             | gcc 14.2                              |
 | Linux on IBM Z&reg; 64-bit    | RHEL 7.9               | gcc 14.2                              |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 14.2                              |
 | Windows x86 32-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 13               | xcode 15.2 and clang 15.0.0           |
@@ -276,7 +276,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux x86 64-bit              | CentOS 6.10            | gcc 14.2                              |
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 14.2                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 13               | xcode 15.2 and clang 15.0.0           |
 | macOS AArch64                 | macOS 13               | xcode 15.2 and clang 15.0.0           |
@@ -289,7 +289,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux x86 64-bit              | CentOS 7.9             | gcc 14.2                              |
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 14.2                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 13               | xcode 15.2 and clang 15.0.0           |
 | macOS AArch64                 | macOS 13               | xcode 15.2 and clang 15.0.0           |
@@ -302,7 +302,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux x86 64-bit              | CentOS 7.9             | gcc 14.2                              |
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 14.2                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 13               | xcode 15.2 and clang 15.0.0           |
 | macOS AArch64                 | macOS 13               | xcode 15.2 and clang 15.0.0           |
@@ -315,7 +315,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux x86 64-bit              | CentOS 7.9             | gcc 14.2                              |
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 14.2                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 14.2                              |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 14.2                              |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 13               | xcode 15.2 and clang 15.0.0           |
 | macOS AArch64                 | macOS 13               | xcode 15.2 and clang 15.0.0           |

--- a/docs/version0.60.md
+++ b/docs/version0.60.md
@@ -27,6 +27,7 @@ The following new features and notable changes since version 0.59.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) [The `-Xcheck:dump` option is enhanced on z/OS systems](#the-xcheckdump-option-is-enhanced-on-zos-systems) ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
+- [Compiler changes for Linux AArch64 64-bit](#compiler-changes-for-linux-aarch64-64-bit)
 
 ## Features and changes
 
@@ -41,6 +42,12 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 The `-Xcheck:dump` option is enhanced on z/OS systems to trigger extra checking for `-Xdump:system` agents. When this option is used, the VM now validates dataset names that are specified in `-Xdump:system` options. This validation allows earlier detection of improper VM options and prevents deployment of misconfigured applications. You can ensure that when system dumps are triggered, your diagnostic dumps will be created successfully and will not fail because of invalid dataset names.
 
 For more information, see [`-Xcheck:dump`](xcheck.md#dump). ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
+
+### Compiler changes for Linux AArch64 64-bit
+
+Linux AArch64 64-bit builds on all OpenJDK versions now use the gcc 14.2 compiler.
+
+For more information, see [Supported environments](openj9_support.md).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1727

Updated the Supported environments and what's new topics for 0.60 release.

Closes #1727
Signed-off-by: Sujatha Mohan sujatha.mohan@ibm.com