### PR TITLE
Update the Dockerfile to use Ubuntu 24.04

### DIFF
--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2025 IBM Corp. and others
+# Copyright (c) 2017, 2026 IBM Corp. and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -20,25 +20,25 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 #
 
-FROM public.ecr.aws/lts/ubuntu:22.04_stable@sha256:f7054b7d5262af3ffbb794eddc1e9e3331cdbd6adbb0be788d7f139c1aad5c48
+FROM public.ecr.aws/lts/ubuntu:24.04_stable@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648
 MAINTAINER openj9.bot <openj9.bot@gmail.com>
 
 # Install basic requirementes from APT. Set up for SSH (including SSH login fix to prevent user being logged out), install and setup  virtualenv from pip3
 COPY requirements.* /tmp/
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-dev python3-pip git openjdk-11-jdk zip \
+RUN echo "UTC" > /etc/timezone \
+    && apt-get update && apt-get install -y --no-install-recommends python3 python3-dev python3-pip python3-virtualenv git openjdk-11-jdk zip \
     && DEBIAN_FRONTEND="noninteractive" apt-get -q upgrade -y -o Dpkg::Options::="--force-confnew" --no-install-recommends \
     && DEBIAN_FRONTEND="noninteractive" apt-get -q install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends openssh-server \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd \
     && mkdir -p /var/run/sshd \
-    && pip3 install virtualenv \
     && virtualenv myenv -p python3
 # Update LANG to fix error with pip-tools
 ENV LANG=C.UTF-8
 # Update path to include the virtual env install location
-ENV PATH /myenv/bin:$PATH
+ENV PATH=/myenv/bin:$PATH
 # Activate the virtualenv environment, install build and test tools, create a new dependency list, and change permissions to ensure that Jenkins modify packages where necessary
-RUN /bin/bash -c "source /myenv/bin/activate && pip3 install 'pip<25.3' pip-tools setuptools && pip3 install --requirement /tmp/requirements.txt && mv /tmp/requirements.txt /tmp/requirements.orig && pip-compile /tmp/requirements.in && chmod -R ugo+w /myenv"
+RUN /bin/bash -c "source /myenv/bin/activate && pip3 install pip pip-tools setuptools && pip3 install --requirement /tmp/requirements.txt && mv /tmp/requirements.txt /tmp/requirements.orig && pip-compile /tmp/requirements.in && chmod -R ugo+w /myenv"
 # Setup jenkins user
 RUN  useradd -m -d /home/jenkins -s /bin/sh jenkins \
     && echo "jenkins:jenkinspass" | chpasswd \


### PR DESCRIPTION
Merging https://github.com/eclipse-openj9/openj9-docs/pull/1741 broke image creation as below (https://openj9-jenkins.osuosl.org/view/Website-Doc/job/Build-Doc-Docker_Container/98). My solution is to update to Ubuntu 24, which we should have done earlier anyway.

Without `echo "UTC" > /etc/timezone`, you end up with /etc/timezone containing `/UTC` and then python doesn't work. Apparently this is a side-effect of installing openjdk-11-jdk which installs tzdata. With this fix /etc/timezone ends up containing `Etc/UTC`.

Using pip earlier than 25.3 (https://github.com/eclipse-openj9/openj9-docs/pull/1622) is no longer required.

```
11:49:59  26.44 Traceback (most recent call last):
11:49:59  26.44   File "/myenv/bin/pip-compile", line 3, in <module>
11:49:59  26.44     from piptools.scripts.compile import cli
11:49:59  26.44   File
"/myenv/lib/python3.10/site-packages/piptools/scripts/compile.py", line
31, in <module>
11:49:59  26.44     from ..writer import OutputWriter
11:49:59  26.44   File
"/myenv/lib/python3.10/site-packages/piptools/writer.py", line 33, in
<module>
11:49:59  26.44     from typing_extensions import Self as _t_Self
11:49:59  26.44 ModuleNotFoundError: No module named 'typing_extensions'
```